### PR TITLE
Handle percents in non-alpha channels using the color function

### DIFF
--- a/coloraide/colors/_gamut.py
+++ b/coloraide/colors/_gamut.py
@@ -1,16 +1,13 @@
 """Gamut handling."""
 from .. import util
+from . _range import Angle
 
 
-class GamutAngle(float):
-    """Gamut hue."""
-
-
-class GamutBound(float):
+class GamutBound(tuple):
     """Bounded gamut value."""
 
 
-class GamutUnbound(float):
+class GamutUnbound(tuple):
     """Unbounded gamut value."""
 
 
@@ -75,21 +72,21 @@ def clip(base, color):
     """Gamut clipping."""
 
     channels = color.coords()
-    gamut = color._gamut
+    gamut = color._range
     fit = []
 
     for i, value in enumerate(channels):
         a, b = gamut[i]
+        is_bound = isinstance(gamut[i], GamutBound)
 
         # Wrap the angle. Not technically out of gamut, but we will clean it up.
-        if isinstance(a, GamutAngle) and isinstance(b, GamutAngle):
+        if isinstance(a, Angle) and isinstance(b, Angle):
             fit.append(value if 0.0 <= value <= 360.0 else value % 360.0)
             continue
 
         # These parameters are unbounded
-        if isinstance(a, GamutUnbound):
+        if not is_bound:
             a = None
-        if isinstance(b, GamutUnbound):
             b = None
 
         # Fit value in bounds.
@@ -162,16 +159,16 @@ class Gamut:
         # Verify the values are in bound
         channels = self.coords()
         for i, value in enumerate(channels):
-            a, b = self._gamut[i]
+            a, b = self._range[i]
+            is_bound = isinstance(self._range[i], GamutBound)
 
             # Angles will wrap, so no sense checking them
-            if isinstance(a, GamutAngle) and isinstance(b, GamutAngle):
+            if isinstance(a, Angle) and isinstance(b, Angle):
                 continue
 
             # These parameters are unbounded
-            if isinstance(a, GamutUnbound):
+            if not is_bound:
                 a = None
-            if isinstance(b, GamutUnbound):
                 b = None
 
             # Check if bounded values are in bounds

--- a/coloraide/colors/_parse.py
+++ b/coloraide/colors/_parse.py
@@ -55,6 +55,16 @@ def norm_percent_channel(value, scale=False):
         raise ValueError("Unexpected value '{}'".format(value))
 
 
+def norm_color_channel(value, scale=True):
+    """Normalize percent channel."""
+
+    if value.endswith('%'):
+        value = norm_float(value[:-1])
+        return value / 100.0 if scale else value
+    else:
+        return norm_float(value)
+
+
 def norm_rgb_channel(value):
     """Normalize RGB channel."""
 

--- a/coloraide/colors/_range.py
+++ b/coloraide/colors/_range.py
@@ -1,0 +1,9 @@
+"""Range."""
+
+
+class Angle(float):
+    """Angle type."""
+
+
+class Percent(float):
+    """Percent type."""

--- a/coloraide/colors/_rgb.py
+++ b/coloraide/colors/_rgb.py
@@ -9,10 +9,10 @@ from .. import util
 class RGB(Space):
     """SRGB class."""
 
-    _gamut = (
-        (GamutBound(0.0), GamutBound(1.0)),
-        (GamutBound(0.0), GamutBound(1.0)),
-        (GamutBound(0.0), GamutBound(1.0))
+    _range = (
+        GamutBound([0.0, 1.0]),
+        GamutBound([0.0, 1.0]),
+        GamutBound([0.0, 1.0])
     )
 
     CHANNEL_NAMES = frozenset(["red", "green", "blue", "alpha"])

--- a/coloraide/colors/_space.py
+++ b/coloraide/colors/_space.py
@@ -6,6 +6,7 @@ from . import _distance as distance
 from . import _gamut as gamut
 from . import _interpolate as interpolate
 from . import _contrast as contrast
+from . _range import Percent
 
 # Technically this form can handle any number of channels as long as any
 # extra are thrown away. We only support 6 currently. If we ever support
@@ -13,7 +14,7 @@ from . import _contrast as contrast
 RE_DEFAULT_MATCH = r"""(?xi)
 color\(\s*
 (?:({{color_space}})\s+)?
-({float}(?:{space}{float}){{{{,6}}}}(?:{slash}(?:{percent}|{float}))?)
+((?:{percent}|{float})(?:{space}(?:{percent}|{float})){{{{,6}}}}(?:{slash}(?:{percent}|{float}))?)
 \s*\)
 """.format(
     **parse.COLOR_PARTS
@@ -34,7 +35,8 @@ def split_channels(cls, color):
         alpha = parse.norm_alpha_channel(split[-1])
     for i, c in enumerate(parse.RE_CHAN_SPLIT.split(split[0]), 0):
         if c and i < cls.NUM_COLOR_CHANNELS:
-            channels.append(float(c))
+            is_percent = isinstance(cls._range[i][0], Percent)
+            channels.append(parse.norm_color_channel(c, not is_percent))
     if len(channels) < cls.NUM_COLOR_CHANNELS:
         diff = cls.NUM_COLOR_CHANNELS - len(channels)
         channels.extend([0.0] * diff)

--- a/coloraide/colors/hsl.py
+++ b/coloraide/colors/hsl.py
@@ -1,7 +1,8 @@
 """HSL class."""
 from ._space import Space, RE_DEFAULT_MATCH
 from ._cylindrical import Cylindrical
-from ._gamut import GamutBound, GamutAngle
+from ._gamut import GamutBound
+from . _range import Angle, Percent
 from . import _parse as parse
 from . import _convert as convert
 from .. import util
@@ -16,10 +17,10 @@ class HSL(Cylindrical, Space):
     CHANNEL_NAMES = frozenset(["hue", "saturation", "lightness", "alpha"])
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
 
-    _gamut = (
-        (GamutAngle(0.0), GamutAngle(360.0)),
-        (GamutBound(0.0), GamutBound(100.0)),
-        (GamutBound(0.0), GamutBound(100.0))
+    _range = (
+        GamutBound([Angle(0.0), Angle(360.0)]),
+        GamutBound([Percent(0.0), Percent(100.0)]),
+        GamutBound([Percent(0.0), Percent(100.0)])
     )
 
     def __init__(self, color=DEF_BG):

--- a/coloraide/colors/hsv.py
+++ b/coloraide/colors/hsv.py
@@ -1,7 +1,8 @@
 """HSV class."""
 from ._space import Space, RE_DEFAULT_MATCH
 from ._cylindrical import Cylindrical
-from ._gamut import GamutBound, GamutAngle
+from ._gamut import GamutBound
+from . _range import Angle, Percent
 from . import _convert as convert
 from . import _parse as parse
 from .. import util
@@ -16,10 +17,10 @@ class HSV(Cylindrical, Space):
     CHANNEL_NAMES = frozenset(["hue", "saturation", "value", "alpha"])
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
 
-    _gamut = (
-        (GamutAngle(0.0), GamutAngle(360.0)),
-        (GamutBound(0.0), GamutBound(100.0)),
-        (GamutBound(0.0), GamutBound(100.0))
+    _range = (
+        GamutBound([Angle(0.0), Angle(360.0)]),
+        GamutBound([Percent(0.0), Percent(100.0)]),
+        GamutBound([Percent(0.0), Percent(100.0)])
     )
 
     def __init__(self, color=DEF_BG):

--- a/coloraide/colors/hwb.py
+++ b/coloraide/colors/hwb.py
@@ -1,7 +1,8 @@
 """HWB class."""
 from ._space import Space, RE_DEFAULT_MATCH
 from ._cylindrical import Cylindrical
-from ._gamut import GamutBound, GamutAngle
+from ._gamut import GamutBound
+from . _range import Angle, Percent
 from . import _convert as convert
 from . import _parse as parse
 from .. import util
@@ -16,10 +17,10 @@ class HWB(Cylindrical, Space):
     CHANNEL_NAMES = frozenset(["hue", "blackness", "whiteness", "alpha"])
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
 
-    _gamut = (
-        (GamutAngle(0.0), GamutAngle(360.0)),
-        (GamutBound(0.0), GamutBound(100.0)),
-        (GamutBound(0.0), GamutBound(100.0))
+    _range = (
+        GamutBound([Angle(0.0), Angle(360.0)]),
+        GamutBound([Percent(0.0), Percent(100.0)]),
+        GamutBound([Percent(0.0), Percent(100.0)])
     )
 
     def __init__(self, color=DEF_BG):

--- a/coloraide/colors/lab.py
+++ b/coloraide/colors/lab.py
@@ -1,6 +1,7 @@
 """LAB class."""
 from ._space import Space, RE_DEFAULT_MATCH
-from ._gamut import GamutUnbound, GamutBound
+from ._gamut import GamutUnbound
+from . _range import Percent
 from . import _convert as convert
 from . import _parse as parse
 from .. import util
@@ -15,10 +16,10 @@ class LAB(Space):
     CHANNEL_NAMES = frozenset(["lightness", "a", "b", "alpha"])
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
 
-    _gamut = (
-        (GamutBound(0), GamutUnbound(100.0)),  # Technically we could/should clamp the zero side.
-        (GamutUnbound(-160), GamutUnbound(160)),  # No limit, but we could impose one +/-160?
-        (GamutUnbound(-160), GamutUnbound(160))  # No limit, but we could impose one +/-160?
+    _range = (
+        GamutUnbound([Percent(0), Percent(100.0)]),  # Technically we could/should clamp the zero side.
+        GamutUnbound([-160, 160]),  # No limit, but we could impose one +/-160?
+        GamutUnbound([-160, 160])  # No limit, but we could impose one +/-160?
     )
 
     def __init__(self, color=DEF_BG):

--- a/coloraide/colors/lch.py
+++ b/coloraide/colors/lch.py
@@ -1,7 +1,8 @@
 """LCH class."""
 from ._space import Space, RE_DEFAULT_MATCH
 from ._cylindrical import Cylindrical
-from ._gamut import GamutUnbound, GamutAngle
+from ._gamut import GamutUnbound
+from . _range import Angle, Percent
 from . import _convert as convert
 from . import _parse as parse
 from .. import util
@@ -16,14 +17,14 @@ class LCH(Cylindrical, Space):
     CHANNEL_NAMES = frozenset(["lightness", "chroma", "hue", "alpha"])
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
 
-    _gamut = (
-        # I think chroma, specifically should be clamped. Generally many
-        # some don't to prevent rounding issues. We should only get
+    _range = (
+        # I think chroma, specifically should be clamped.
+        # Some libraries don't to prevent rounding issues. We should only get
         # negative chroma via direct user input, but when translating to
         # Lab, this will be corrected.
-        (GamutUnbound(0.0), GamutUnbound(100.0)),
-        (GamutUnbound(0.0), GamutUnbound(100.0)),
-        (GamutAngle(0.0), GamutAngle(360.0)),
+        GamutUnbound([Percent(0.0), Percent(100.0)]),
+        GamutUnbound([0.0, 100.0]),
+        GamutUnbound([Angle(0.0), Angle(360.0)]),
     )
 
     def __init__(self, color=DEF_BG):

--- a/coloraide/colors/xyz.py
+++ b/coloraide/colors/xyz.py
@@ -15,10 +15,10 @@ class XYZ(Space):
     CHANNEL_NAMES = frozenset(["x", "y", "z", "alpha"])
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
 
-    _gamut = (
-        (GamutUnbound(0.0), GamutUnbound(1.0)),
-        (GamutUnbound(0.0), GamutUnbound(1.0)),
-        (GamutUnbound(0.0), GamutUnbound(1.0))
+    _range = (
+        GamutUnbound([0.0, 1.0]),
+        GamutUnbound([0.0, 1.0]),
+        GamutUnbound([0.0, 1.0])
     )
 
     def __init__(self, color=DEF_BG):


### PR DESCRIPTION
This is intended to close #5.

Unfortunately, there is some uncertainty about the implementation. Currently, like colorjs, we blindly just treat percentages as a representation of values in the range 0 - 1, even if the color space we are referring to does not store their values as such. The spec is unclear of how this should be handled, and I'm not yet convinced that colorjs is doing it as intended, but maybe they are. Really, it all comes down to what the spec intends, which is currently ambiguous.

This is a work in progress as we need to understand what the true intention is.

@gir-bot add S: work-in-progress