### PR TITLE
Require the color space in color() function

### DIFF
--- a/coloraide/colors/_space.py
+++ b/coloraide/colors/_space.py
@@ -50,7 +50,6 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
     DEF_BG = ""
     SPACE = ""
     NUM_COLOR_CHANNELS = 3
-    IS_DEFAULT = False
     CHANNEL_NAMES = frozenset(["alpha"])
     # For matching the default form of `color(space coords+ / alpha)`.
     # Classes should define this if they want to use the default match.
@@ -181,8 +180,7 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
         if (
             m is not None and
             (
-                (m.group(1) and m.group(1).lower() == cls.space()) or
-                (not m.group(1) and cls.IS_DEFAULT)
+                (m.group(1) and m.group(1).lower() == cls.space())
             ) and (not fullmatch or m.end(0) == len(string))
         ):
             return split_channels(cls, m.group(2)), m.end(0)

--- a/coloraide/colors/srgb.py
+++ b/coloraide/colors/srgb.py
@@ -9,7 +9,6 @@ class SRGB(RGB):
 
     SPACE = "srgb"
     DEF_BG = "color(srgb 0 0 0 / 1)"
-    IS_DEFAULT = True
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
 
     def __init__(self, color=DEF_BG):

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -1,4 +1,4 @@
-# ColorAide
+# Setup
 
 ## Overview
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,14 +23,15 @@ theme:
     - navigation.tabs
 
 nav:
-  - ColorAide: index.md
-  - The Color Object: color.md
-  - Manipulating Colors: manipulation.md
-  - Color Interpolation: interpolation.md
-  - Color Distance and Delta E: distance.md
-  - Gamut Mapping: gamut.md
-  - Contrast: contrast.md
-  - String Output: strings.md
+  - ColorAide:
+      - Setup: index.md
+      - The Color Object: color.md
+      - Manipulating Colors: manipulation.md
+      - Color Interpolation: interpolation.md
+      - Color Distance and Delta E: distance.md
+      - Gamut Mapping: gamut.md
+      - Contrast: contrast.md
+      - String Output: strings.md
   - Color Spaces:
       - Supported Colors: colors/index.md
   - API:


### PR DESCRIPTION
Recent change in the CSS specification now requires color to specify
the space if not using the form `color(<digit>+)`. So no more assumed
srgb space.