### PR TITLE
Fix hue-specified not working

### DIFF
--- a/coloraide/colors/_convert.py
+++ b/coloraide/colors/_convert.py
@@ -2,6 +2,12 @@
 from .. import util
 
 
+def constrain_hue(hue):
+    """Constrain hue to 0 - 360."""
+
+    return hue % 360
+
+
 def d50_to_d65(xyz):
     """Bradford chromatic adaptation from D50 to D65."""
 
@@ -37,9 +43,6 @@ def d65_to_d50(xyz):
 class Convert:
     """Convert class."""
 
-    def _on_convert(self):
-        """Run after a convert operation to give an opportunity to do some post convert actions."""
-
     def convert(self, space, *, fit=False):
         """Convert to color space."""
 
@@ -51,7 +54,6 @@ class Convert:
                 clone = self.clone()
                 clone.fit(space, method=method, in_place=True)
                 result = clone.convert(space)
-                result._on_convert()
                 return result
 
         convert_to = '_to_{}'.format(space)
@@ -83,14 +85,13 @@ class Convert:
         coords = list(coords) + [self.alpha]
         result = obj(coords)
         result.parent = self.parent
-        result._on_convert()
+
         return result
 
     def update(self, obj):
         """Update from color."""
 
         if self is obj:
-            self._on_convert()
             return
 
         if not isinstance(obj, type(self)):
@@ -99,5 +100,4 @@ class Convert:
         for i, value in enumerate(obj.coords()):
             self._coords[i] = value
         self.alpha = obj.alpha
-        self._on_convert()
         return self

--- a/coloraide/colors/_cylindrical.py
+++ b/coloraide/colors/_cylindrical.py
@@ -18,13 +18,3 @@ class Cylindrical:
         """Get hue index."""
 
         return 0
-
-    def _on_convert(self):
-        """
-        Run after a convert operation.
-
-        Gives us an opportunity to normalize hues.
-        """
-
-        if not (0.0 <= self.hue <= 360.0):
-            self.hue = self.hue % 360.0

--- a/coloraide/colors/_parse.py
+++ b/coloraide/colors/_parse.py
@@ -114,15 +114,13 @@ def norm_angle(angle):
 def norm_hue_channel(value):
     """Normalize hex channel."""
 
-    angle = norm_angle(value)
-    return angle if not (0.0 <= angle <= 360) else angle % 360.0
+    return norm_angle(value)
 
 
 def norm_deg_channel(value):
     """Normalize degree channel."""
 
-    value = norm_float(value)
-    return value if not (0.0 <= value <= 360) else value % 360.0
+    return norm_float(value)
 
 
 def bracket_match(match, string, start, fullmatch):

--- a/coloraide/colors/hsl.py
+++ b/coloraide/colors/hsl.py
@@ -5,6 +5,7 @@ from ._cylindrical import Cylindrical
 from ._gamut import GamutBound
 from . _range import Angle, Percent
 from . import _parse as parse
+from . import _convert as convert
 from .. import util
 import re
 
@@ -29,7 +30,7 @@ def srgb_to_hsl(rgb):
         else:
             h = (r - g) / c + 4.0
 
-    return h * 60.0, s * 100.0, l * 100.0
+    return convert.constrain_hue(h * 60.0), s * 100.0, l * 100.0
 
 
 def hsl_to_srgb(hsl):
@@ -95,16 +96,6 @@ class HSL(Cylindrical, Space):
 
         h, s, l = self.coords()
         return s < util.ACHROMATIC_THRESHOLD
-
-    def _on_convert(self):
-        """
-        Run after a convert operation.
-
-        Gives us an opportunity to normalize hues and things like that, if we desire.
-        """
-
-        if not (0.0 <= self.hue <= 360.0):
-            self.hue = self.hue % 360.0
 
     @property
     def hue(self):

--- a/coloraide/colors/hsv.py
+++ b/coloraide/colors/hsv.py
@@ -6,6 +6,7 @@ from ._cylindrical import Cylindrical
 from ._gamut import GamutBound
 from . _range import Angle, Percent
 from . import _parse as parse
+from . import _convert as convert
 from .. import util
 import re
 
@@ -23,7 +24,7 @@ def hsv_to_hsl(hsv):
     l = v * (1.0 - s / 2.0)
 
     return [
-        h,
+        convert.constrain_hue(h),
         0.0 if (l == 0.0 or l == 0.0) else ((v - l) / min(l, 1.0 - l)) * 100,
         l * 100
     ]
@@ -43,7 +44,7 @@ def hsl_to_hsv(hsl):
     v = l + s * min(l, 1.0 - l)
 
     return [
-        h,
+        convert.constrain_hue(h),
         0.0 if (v == 0.0) else 200.0 * (1.0 - l / v),
         100.0 * v
     ]

--- a/coloraide/colors/hwb.py
+++ b/coloraide/colors/hwb.py
@@ -7,6 +7,7 @@ from ._cylindrical import Cylindrical
 from ._gamut import GamutBound
 from . _range import Angle, Percent
 from . import _parse as parse
+from . import _convert as convert
 from .. import util
 import re
 
@@ -17,7 +18,7 @@ def srgb_to_hwb(rgb):
     h, s, v = HSV._from_srgb(rgb)
     w = v * (100.0 - s) / 100.0
     b = 100.0 - v
-    return h, w, b
+    return convert.constrain_hue(h), w, b
 
 
 def hwb_to_srgb(hwb):

--- a/coloraide/colors/lch.py
+++ b/coloraide/colors/lch.py
@@ -5,6 +5,7 @@ from ._cylindrical import Cylindrical
 from ._gamut import GamutUnbound
 from . _range import Angle, Percent
 from . import _parse as parse
+from . import _convert as convert
 from .. import util
 import re
 import math
@@ -20,7 +21,7 @@ def lab_to_lch(lab):
     return (
         l,
         math.sqrt(math.pow(a, 2) + math.pow(b, 2)),
-        math.atan2(b, a) * 180 / math.pi
+        convert.constrain_hue(math.atan2(b, a) * 180 / math.pi)
     )
 
 

--- a/docs/src/markdown/interpolation.md
+++ b/docs/src/markdown/interpolation.md
@@ -9,18 +9,18 @@ Interpolation functions accept an input between 0 - 1, if values are provided ou
 extrapolated and the results may be surprising.
 
 Here we create a an interpolation between `#!color rebeccapurple` and `#!color-fit lch(85% 100 85)` (color previews are
-fit to the sRGB gamut). We then step through values of `0.1`, `0.2`, and `0.3` which creates: \[
-`#!color-swatch rgb(102 51 153)`,
-`#!color-swatch rgb(142.02 45.34 154.31)`,
-`#!color-swatch rgb(178.58 36.391 149.5)`,
-`#!color-swatch rgb(211.11 28.452 139.16)`,
-`#!color-swatch rgb(238.61 32.963 124.24)`,
-`#!color-swatch rgb(255 53.083 105.75)`,
-`#!color-swatch rgb(249.21 108.41 101.4)`,
-`#!color-swatch rgb(255 130.24 87.774)`,
-`#!color-swatch rgb(255 154.42 74.129)`,
-`#!color-swatch rgb(255 179.93 62.148)`
-\].
+fit to the sRGB gamut). We then step through values of `0.1`, `0.2`, `0.3`, etc. which creates a range colors that we
+can use in a gradient to get:
+`#!color-gradient rgb(102 51 153);
+rgb(142.02 45.34 154.31);
+rgb(178.58 36.391 149.5);
+rgb(211.11 28.452 139.16);
+rgb(238.61 32.963 124.24);
+rgb(255 53.083 105.75);
+rgb(249.21 108.41 101.4);
+rgb(255 130.24 87.774);
+rgb(255 154.42 74.129);
+rgb(255 179.93 62.148)`.
 
 ```pycon3
 >>> i = Color("rebeccapurple").interpolate("lch(85% 100 85)", space='lch')
@@ -39,46 +39,82 @@ fit to the sRGB gamut). We then step through values of `0.1`, `0.2`, and `0.3` w
 'rgb(255 179.93 62.148)'
 ```
 
-If desired, we can target specific channels for mixing which will keep all the other channels constant on the base
-color. In this example, we have a base color of `#!color lch(52% 58.1 22.7)` which we mix with
-`#!color lch(56% 49.1 257.1)`. We also specify that we want to only mix the `hue` channel. The final color is
-`#!color lch(52% 58.1 351.59)`. Notice that when comparing to the base color that only the `hue` has changed.
+If desired, we can target one or more specific channels for mixing which will keep all the other channels constant on
+the base color. Channels must be specified for the giving color space that interpolation is occurring in (including
+`alpha`). In this example, we have a base color of `#!color lch(52% 58.1 22.7)` which we mix with
+`#!color lch(56% 49.1 257.1)`. We also specify that we want to only mix the `hue` channel. We can see as we step through
+the colors that only the hue is interpolated:
+
+And when applied to a range, we can see only the hue is adjusted:
+`#!color-gradient lch(52% 58.1 22.7);
+lch(52% 58.1 10.14);
+lch(52% 58.1 357.58);
+lch(52% 58.1 345.02);
+lch(52% 58.1 332.46);
+lch(52% 58.1 319.9);
+lch(52% 58.1 307.34);
+lch(52% 58.1 294.78);
+lch(52% 58.1 282.22);
+lch(52% 58.1 269.66)`.
+
+```pycon3
+>>> i = Color("lch(52% 58.1 22.7)").interpolate("lch(56% 49.1 257.1)", space="lch", adjust=["hue"])
+>>> for x in range(10):
+...     i(x/10).to_string()
+...
+'lch(52% 58.1 22.7)'
+'lch(52% 58.1 10.14)'
+'lch(52% 58.1 357.58)'
+'lch(52% 58.1 345.02)'
+'lch(52% 58.1 332.46)'
+'lch(52% 58.1 319.9)'
+'lch(52% 58.1 307.34)'
+'lch(52% 58.1 294.78)'
+'lch(52% 58.1 282.22)'
+'lch(52% 58.1 269.66)'
+```
+
+Additionally, hues are special, and we can control the way the interpolation is evaluated. The `hue` parameter
+accepts such values as `shorter`, `longer`, `increasing`, `decreasing`, and `specified` (`shorter` being the default).
+Below, we can see how the interpolation varies using `shorter` vs `longer`.
 
 ```pycon3
 >>> i = Color("lch(52% 58.1 22.7)").interpolate("lch(56% 49.1 257.1)", space="lch", adjust=["hue"])
 >>> i(0.2477).to_string()
 'lch(52% 58.1 351.59)'
-```
-
-Additionally, hues are special, and we can control the way the interpolation is evaluated. The `hue` parameter
-accepts such values as `longer` or `shorter`, `shorter` being the default (see API for all options). In this example,
-we run the same command, but specify that the interpolation should use the longer angle between the two hues. This time,
-when we mix `#!color lch(52% 58.1 22.7)` and `#!color lch(56% 49.1 257.1)`, we get a different color
-(`#!color lch(52% 58.1 80.761)`) as we interpolated between the larger angle instead of the shorter angle.
-
-```pycon3
 >>> i = Color("lch(52% 58.1 22.7)").interpolate("lch(56% 49.1 257.1)", space="lch", adjust=["hue"], hue="longer")
 >>> i(0.2477).to_string()
 'lch(52% 58.1 80.761)'
 ```
+
+To help visualize the different hue methods, consider the following evaluation between `#!color rebeccapurple` and
+`#!color lch(85% 85 805)` in the table below. Check out the [CSS level 4 specification](https://drafts.csswg.org/css-color-4/#hue-interpolation)
+to learn more about each one.
+
+Hue\ Logic   | Result
+------------ | ------
+`shorter`    | `#!color-gradient rgb(102 51 153);rgb(122.07 49.312 153.57);rgb(140.94 47.145 152.78);rgb(158.77 44.809 150.7);rgb(175.55 42.8 147.4);rgb(191.24 41.813 143.01);rgb(205.76 42.647 137.62);rgb(219.03 45.921 131.38);rgb(230.97 51.804 124.41);rgb(241.5 60.017 116.84);rgb(250.57 70.08 108.78);rgb(255 81.52 100.32);rgb(255 93.955 91.526);rgb(255 107.09 82.426);rgb(249.89 136.06 97.573);rgb(252.63 147.22 93.303);rgb(254.11 158.75 89.576);rgb(254.34 170.55 86.644);rgb(253.35 182.53 84.812);rgb(255 191.26 16.33)`
+`longer`     | `#!color-gradient rgb(102 51 153);rgb(82.957 67.383 172.52);rgb(49.641 82.343 189.24);rgb(43.047 95.469 174.9);rgb(0 106.83 183.37);rgb(0 116.53 178.89);rgb(0 125.54 175.12);rgb(0 134.29 172.26);rgb(0 142.92 169.41);rgb(0 151.58 166.08);rgb(0 160.34 161.49);rgb(0 172.44 155.98);rgb(0 179.69 143.13);rgb(0 186.29 129.61);rgb(50.666 192.16 116.08);rgb(34.49 202.64 75.11);rgb(100.66 206.25 52.127);rgb(143.92 208.48 25.842);rgb(182.46 209.14 0);rgb(219.08 208.07 0)`
+`increasing` | `#!color-gradient rgb(102 51 153);rgb(122.07 49.312 153.57);rgb(140.94 47.145 152.78);rgb(158.77 44.809 150.7);rgb(175.55 42.8 147.4);rgb(191.24 41.813 143.01);rgb(205.76 42.647 137.62);rgb(219.03 45.921 131.38);rgb(230.97 51.804 124.41);rgb(241.5 60.017 116.84);rgb(250.57 70.08 108.78);rgb(255 81.52 100.32);rgb(255 93.955 91.526);rgb(255 107.09 82.426);rgb(249.89 136.06 97.573);rgb(252.63 147.22 93.303);rgb(254.11 158.75 89.576);rgb(254.34 170.55 86.644);rgb(253.35 182.53 84.812);rgb(255 191.26 16.33)`
+`decreasing` | `#!color-gradient rgb(102 51 153);rgb(82.957 67.383 172.52);rgb(49.641 82.343 189.24);rgb(43.047 95.469 174.9);rgb(0 106.83 183.37);rgb(0 116.53 178.89);rgb(0 125.54 175.12);rgb(0 134.29 172.26);rgb(0 142.92 169.41);rgb(0 151.58 166.08);rgb(0 160.34 161.49);rgb(0 172.44 155.98);rgb(0 179.69 143.13);rgb(0 186.29 129.61);rgb(50.666 192.16 116.08);rgb(34.49 202.64 75.11);rgb(100.66 206.25 52.127);rgb(143.92 208.48 25.842);rgb(182.46 209.14 0);rgb(219.08 208.07 0)`
+`specified`  | `#!color-gradient rgb(102 51 153);rgb(147 25.234 128.16);rgb(172.94 0 94.318);rgb(181.29 28.412 57.75);rgb(173.56 64.244 17.031);rgb(144.25 97.533 18.334);rgb(120.61 116.73 10.392);rgb(70.621 136.42 0);rgb(31.554 146.34 74.535);rgb(0 156.86 119.39);rgb(0 160.34 161.49);rgb(0 165.16 198.49);rgb(0 169.39 247.51);rgb(95.342 164.66 255);rgb(174.53 155.16 255);rgb(232.29 143.56 245.64);rgb(255 135.97 212.71);rgb(255 157.98 177.9);rgb(255 156.42 134.12);rgb(255 180.88 102.22)`
 
 !!! tip
     It is important to note that we must specify the channels of the space the interpolation is occurring in.
     Specifying `hue` while interpolating in the sRGB color space would target no channels and would be ignored.
 
 We can also do non-linear interpolation by providing a function. Here we use a function that returns `p ** 3` creating
-the colors (color previews are fit to the sRGB gamut): \[
-`#!color-swatch-fit lch(50% 50 0)`,
-`#!color-swatch-fit lch(50.04% 49.997 0.0196)`,
-`#!color-swatch-fit lch(50.32% 49.976 0.15685)`,
-`#!color-swatch-fit lch(51.08% 49.921 0.52995)`,
-`#!color-swatch-fit lch(52.56% 49.819 1.2588)`,
-`#!color-swatch-fit lch(55% 49.669 2.4666)`,
-`#!color-swatch-fit lch(58.64% 49.487 4.2807)`,
-`#!color-swatch-fit lch(63.72% 49.316 6.831)`,
-`#!color-swatch-fit lch(70.48% 49.241 10.242)`,
-`#!color-swatch-fit lch(79.16% 49.401 14.617)`
-\].
+the colors (color previews are fit to the sRGB gamut):
+`#!color-gradient lch(50% 50 0);
+ lch(50.04% 49.997 0.0196);
+ lch(50.32% 49.976 0.15685);
+ lch(51.08% 49.921 0.52995);
+ lch(52.56% 49.819 1.2588);
+ lch(55% 49.669 2.4666);
+ lch(58.64% 49.487 4.2807);
+ lch(63.72% 49.316 6.831);
+ lch(70.48% 49.241 10.242);
+ lch(79.16% 49.401 14.617)`.
 
 ```pycon3
 >>> i = Color("lch(50% 50 0)").interpolate("lch(90% 50 20)", progress=lambda p: p ** 3)

--- a/docs/theme/colorswatch.css
+++ b/docs/theme/colorswatch.css
@@ -3,6 +3,7 @@
   --swatch-bg-color: white;
   --swatch-bg-alt-color: hsl(0, 0%, 87%);
   --swatch-gamut-border-color: hsl(340 82% 52%);
+  --swatch-stops: transparent, transparent;
 }
 
 :root [data-md-color-scheme="slate"] {
@@ -34,36 +35,43 @@
   box-shadow: 1px 1px 1px rgba(0, 0, 0, .3);
 }
 
-.swatch.out-of-gamut {
-    border-color: var(--swatch-gamut-border-color);
+.swatch-gradient {
+  display: inline-block;
+  border-radius: 0.25em;
+  width: 10em;
 }
 
 .swatch-color {
   display: inline-block;
-  width: 0.5em;
+  margin: 0;
+  padding: 0;
+  border-radius: 100px;
   height: 1em;
+  width: 1em;
+  background: linear-gradient(to right, var(--swatch-stops));
+}
+
+.swatch-gradient .swatch-color {
+  width: 10em;
+  border-radius: 0.10em;
+}
+
+.swatch.out-of-gamut {
+    border-color: var(--swatch-gamut-border-color);
 }
 
 .swatch.out-of-gamut .swatch-color {
   opacity: 0;
 }
 
-.swatch-color:only-child {
-  width: 1em;
-}
-
-.swatch-color:first-child {
-  border-top-left-radius: 100px;
-  border-bottom-left-radius: 100px;
-}
-
-.swatch-color:last-child {
-  border-top-right-radius: 100px;
-  border-bottom-right-radius: 100px;
-}
-
-.swatch:hover {
+span.swatch:not(.swatch-gradient):hover {
   z-index: 2;
-  transform: scale(2);
+  transform: scale(1.7);
+  translateY(10%);
+}
+
+span.swatch.swatch-gradient:hover {
+  z-index: 2;
+  transform: scale(1.3);
   translateY(10%);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,9 @@ markdown_extensions:
         - name: color-swatch-fit
           class: color
           format: !!python/name:tools.colors.color_formatter_color_only_fit
+        - name: color-gradient
+          class: color
+          format: !!python/name:tools.colors.color_gradient_formatter
   - pymdownx.magiclink:
       repo_url_shortener: true
       repo_url_shorthand: true

--- a/tools/colors.py
+++ b/tools/colors.py
@@ -3,16 +3,6 @@ from coloraide.css import Color
 import xml.etree.ElementTree as Etree
 
 
-def _escape(txt):
-    """Basic HTML escaping."""
-
-    txt = txt.replace('&', '&amp;')
-    txt = txt.replace('<', '&lt;')
-    txt = txt.replace('>', '&gt;')
-    txt = txt.replace('"', '&quot;')
-    return txt
-
-
 def _color_formatter(src="", language="", class_name=None, md="", show_code=True, fit=False):
     """Formatter wrapper."""
 
@@ -20,36 +10,67 @@ def _color_formatter(src="", language="", class_name=None, md="", show_code=True
     try:
         color = Color(src)
         el = Etree.Element('span')
+        stops = []
         if not color.in_gamut("srgb"):
             if fit:
                 color.fit("srgb", in_place=True)
                 attributes = {'class': "swatch", "title": src}
                 sub_el = Etree.SubElement(el, 'span', attributes)
+                stops.append(color.convert("srgb").to_string(hex=True, alpha=False))
+                if color.alpha < 1.0:
+                    stops[-1] += ' 50%'
+                    stops.append(color.convert("srgb").to_string(hex=True) + ' 50%')
             else:
                 attributes = {'class': "swatch out-of-gamut", "title": "Out of Gamut&#10;{}".format(src)}
                 sub_el = Etree.SubElement(el, 'span', attributes)
         else:
             attributes = {'class': "swatch", "title": src}
             sub_el = Etree.SubElement(el, 'span', attributes)
+            stops.append(color.convert("srgb").to_string(hex=True, alpha=False))
+            if color.alpha < 1.0:
+                stops[-1] += ' 50%'
+                stops.append(color.convert("srgb").to_string(hex=True) + ' 50%')
+
+        if not stops:
+            stops.extend(['transparent'] * 2)
+        if len(stops) == 1:
+            stops.append(stops[0])
+
         Etree.SubElement(
             sub_el,
             'span',
             {
                 "class": "swatch-color",
-                "style": "background-color: {};".format(color.convert("srgb").to_string(hex=True, alpha=False))
+                "style": "--swatch-stops: {};".format(','.join(stops))
             }
         )
-        if color.alpha < 1.0:
-            Etree.SubElement(
-                sub_el,
-                'span',
-                {
-                    "class": "swatch-color",
-                    "style": "background-color: {};".format(color.convert("srgb").to_string(hex=True))
-                }
-            )
+
         if show_code:
             el.append(md.inlinePatterns['backtick'].handle_code('', src))
+    except Exception:
+        el = md.inlinePatterns['backtick'].handle_code('', src)
+    return el
+
+
+def color_gradient_formatter(src="", language="", class_name=None, md=""):
+    """Format gradient."""
+
+    src_color = [c.strip() for c in src.strip().split(';')]
+
+    el = Etree.Element('span', {'class': "swatch swatch-gradient"})
+    try:
+        style = "--swatch-stops: "
+        stops = []
+        for c in src_color:
+            color = Color(c)
+            color.fit("srgb", in_place=True)
+            stops.append(color.convert("srgb").to_string(hex=True))
+        if not stops:
+            stops.extend(['transparent'] * 2)
+        if len(stops) == 1:
+            stops.append(stops[0])
+        style += ','.join(stops)
+        Etree.SubElement(el, 'span', {'class': 'swatch-color', 'style': style})
     except Exception:
         el = md.inlinePatterns['backtick'].handle_code('', src)
     return el


### PR DESCRIPTION
We were always constraining hue to be between 0-360, so it was
impossible for us to properly implement hue "specified" logic.

Fix hue so that it is only constrained when an actual conversion
between spaces occurs.

Also, add gradient boxes to docs and visualize hue logic.