### PR TITLE
Better gamut handling

### DIFF
--- a/coloraide/colors/_space.py
+++ b/coloraide/colors/_space.py
@@ -57,6 +57,20 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
     # Match pattern variable for classes to override so we can also
     # maintain the default and other alternatives.
     MATCH = ""
+    # Should this color be mapped in a different space? Only when set to a string (specifying a color space) will the
+    # default gamut mapping be overridden by the specified color space.
+    #
+    # Gamut checking:
+    #   The specified color space will be checked first followed by the original. Assuming the parent color space fits,
+    #   the original should fit as well, but there are some cases when a parent color space that is slightly out of
+    #   gamut, when evaluated with a threshold, may appear to be in gamut enough, but when checking the original color
+    #   space, the values can be greatly out of specification (looking at you HSL).
+    #
+    # Gamut mapping:
+    #   Since gamut mapping forces "in gamut" checks without thresholds, if a color is forced into it's parent gamut,
+    #   the coordinates for the derived color space should be within spec. We only normalize angles outside of 0-360
+    #   after the parent color space is fit.
+    GAMUT = None
 
     def __init__(self, color=None):
         """Initialize."""

--- a/coloraide/colors/hsl.py
+++ b/coloraide/colors/hsl.py
@@ -61,6 +61,7 @@ class HSL(Cylindrical, Space):
     DEF_BG = "color(hsl 0 0 0 / 1)"
     CHANNEL_NAMES = frozenset(["hue", "saturation", "lightness", "alpha"])
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
+    GAMUT = "srgb"
 
     _range = (
         GamutBound([Angle(0.0), Angle(360.0)]),

--- a/coloraide/colors/hsv.py
+++ b/coloraide/colors/hsv.py
@@ -57,6 +57,7 @@ class HSV(Cylindrical, Space):
     DEF_BG = "color(hsv 0 0 0 / 1)"
     CHANNEL_NAMES = frozenset(["hue", "saturation", "value", "alpha"])
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
+    GAMUT = "srgb"
 
     _range = (
         GamutBound([Angle(0.0), Angle(360.0)]),

--- a/coloraide/colors/hwb.py
+++ b/coloraide/colors/hwb.py
@@ -42,6 +42,7 @@ class HWB(Cylindrical, Space):
     DEF_BG = "color(hwb 0 0 0 / 1)"
     CHANNEL_NAMES = frozenset(["hue", "blackness", "whiteness", "alpha"])
     DEFAULT_MATCH = re.compile(RE_DEFAULT_MATCH.format(color_space=SPACE))
+    GAMUT = "srgb"
 
     _range = (
         GamutBound([Angle(0.0), Angle(360.0)]),


### PR DESCRIPTION
1. HSL, HSV, and HWB should use sRGB to determine if they are in gamut
   as they are just cylindrical representations of sRGB.
2. While point (1) is true, there are cases, due to conversion
   algorithms, where an sRGB color may be slightly out of gamut (and
   within the allowable threshold) and appear in gamut, but the
   cylindrical representation is grossly out of spec. In this case, we
   should at least make sure the cylindrical representation is within an
   allowable threshold as well.
3. When fitting, fitting the parent gamut (in the case of HSL, the
   parent being sRGB) if the parent is fit, the child should fit as no
   threshold is used when fitting.
4. When passing anything through fit, we will always normalize angles to
   be between 0-360 for consistency.