### PR TITLE
Clean up code and API

### DIFF
--- a/coloraide/__init__.py
+++ b/coloraide/__init__.py
@@ -2,5 +2,6 @@
 from .__meta__ import __version_info__, __version__  # noqa: F401
 from .css import Color
 from .colors import ColorMatch
+from .util import NaN
 
-__all__ = ("Color", "ColorMatch")
+__all__ = ("Color", "ColorMatch", "NaN")

--- a/coloraide/__meta__.py
+++ b/coloraide/__meta__.py
@@ -189,5 +189,5 @@ def parse_version(ver):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(0, 1, 0, "alpha", 3)
+__version_info__ = Version(0, 1, 0, "alpha", 4)
 __version__ = __version_info__._get_canonical()

--- a/coloraide/colors/__init__.py
+++ b/coloraide/colors/__init__.py
@@ -12,7 +12,6 @@ from .prophoto_rgb import ProPhoto_RGB
 from .rec2020 import Rec2020
 from .xyz import XYZ
 from .. import util
-from ._cylindrical import Cylindrical
 import functools
 
 DEF_FIT = "lch-chroma"
@@ -54,33 +53,19 @@ class Color:
 
     CS_MAP = {obj.space(): obj for obj in SUPPORTED}
 
+    PRECISION = util.DEF_PREC
+    FIT = util.DEF_FIT
+    DELTA_E = util.DEF_DELTA_E
+
     def __init__(self, color, data=None, alpha=util.DEF_ALPHA, *, filters=None, **kwargs):
         """Initialize."""
 
-        self.defaults = {
-            "fit": DEF_FIT,
-            "delta-e": DEF_DELTA_E
-        }
         self._attach(self._parse(color, data, alpha, filters=filters, **kwargs))
 
-    def is_hue_null(self, space=None):
-        """Check if hue is treated as null."""
+    def is_nan(self, name):
+        """Check if channel is NaN."""
 
-        if space is None:
-            space = self.space()
-        else:
-            space = space.lower()
-
-        this = self if self.space() == space else self.convert(space)
-        if isinstance(this._color, Cylindrical):
-            return this._color.is_hue_null()
-        else:
-            return False
-
-    def get_default(self, name):
-        """Get default."""
-
-        return self.defaults[name]
+        return util.is_nan(self.get(name))
 
     def _attach(self, color):
         """Attach the this objects convert space to the color."""

--- a/coloraide/colors/_convert.py
+++ b/coloraide/colors/_convert.py
@@ -46,7 +46,7 @@ class Convert:
     def _constrain_hue(cls, hue):
         """Constrain hue to 0 - 360."""
 
-        return hue % 360
+        return hue % 360 if not util.is_nan(hue) else hue
 
     @classmethod
     def _chromatic_adaption(cls, w1, w2, xyz):
@@ -110,6 +110,7 @@ class Convert:
         """Update from color."""
 
         if self is obj:
+            obj._coords = obj.null_adjust(obj._coords)
             return
 
         if not isinstance(obj, type(self)):
@@ -118,4 +119,5 @@ class Convert:
         for i, value in enumerate(obj.coords()):
             self._coords[i] = value
         self.alpha = obj.alpha
+        self._coords = self.null_adjust(self._coords)
         return self

--- a/coloraide/colors/_cylindrical.py
+++ b/coloraide/colors/_cylindrical.py
@@ -4,11 +4,6 @@
 class Cylindrical:
     """Cylindrical space."""
 
-    def is_hue_null(self):
-        """Test if hue is null."""
-
-        raise NotImplementedError("Base 'CylindricalSpace' class does not impolement 'is_hue_null'")
-
     def hue_name(self):
         """Hue channel name."""
 

--- a/coloraide/colors/_distance.py
+++ b/coloraide/colors/_distance.py
@@ -1,4 +1,5 @@
 import math
+from .. import util
 
 G_CONST = math.pow(25, 7)
 RAD2DEG = 180 / math.pi
@@ -13,8 +14,8 @@ def distance_euclidean(color1, color2, space="lab", **kwargs):
     lab1 = color1.convert(space)
     lab2 = color2.convert(space)
 
-    coords1 = lab1.coords()
-    coords2 = lab2.coords()
+    coords1 = util.no_nan(lab1.coords())
+    coords2 = util.no_nan(lab2.coords())
 
     total = 0
     for i, coord in enumerate(coords1):
@@ -42,9 +43,9 @@ def delta_e_94(color1, color2, kl=1, k1=0.045, k2=0.015):
     lab1 = color1.convert("lab")
     lab2 = color2.convert("lab")
 
-    l1, a1, b1 = lab1.coords()
+    l1, a1, b1 = util.no_nan(lab1.coords())
     c1 = math.sqrt(math.pow(a1, 2) + math.pow(b1, 2))
-    l2, a2, b2 = lab2.coords()
+    l2, a2, b2 = util.no_nan(lab2.coords())
     c2 = math.sqrt(math.pow(a2, 2) + math.pow(b2, 2))
 
     dl = l1 - l2
@@ -83,9 +84,9 @@ def delta_e_cmc(color1, color2, l=2, c=1):
     lab1 = color1.convert("lab")
     lab2 = color2.convert("lab")
 
-    l1, a1, b1 = lab1.coords()
+    l1, a1, b1 = util.no_nan(lab1.coords())
     c1 = math.sqrt(math.pow(a1, 2) + math.pow(b1, 2))
-    l2, a2, b2 = lab2.coords()
+    l2, a2, b2 = util.no_nan(lab2.coords())
     c2 = math.sqrt(math.pow(a2, 2) + math.pow(b2, 2))
 
     dl = l1 - l2
@@ -145,9 +146,9 @@ def delta_e_2000(color1, color2, kl=1, kc=1, kh=1, **kwargs):
     lab1 = color1.convert("lab")
     lab2 = color2.convert("lab")
 
-    l1, a1, b1 = lab1.coords()
+    l1, a1, b1 = util.no_nan(lab1.coords())
     c1 = math.sqrt(math.pow(a1, 2) + math.pow(b1, 2))
-    l2, a2, b2 = lab2.coords()
+    l2, a2, b2 = util.no_nan(lab2.coords())
     c2 = math.sqrt(math.pow(a2, 2) + math.pow(b2, 2))
 
     cm = (c1 + c2) / 2
@@ -229,7 +230,7 @@ class Distance:
         """Delta E distance."""
 
         if method is None:
-            method = self.get_default("delta-e")
+            method = self.parent.DELTA_E
 
         algorithm = method.lower()
         if algorithm not in SUPPORTED:

--- a/coloraide/colors/_gamut.py
+++ b/coloraide/colors/_gamut.py
@@ -71,7 +71,7 @@ def lch_chroma(base, color):
 def clip(base, color):
     """Gamut clipping."""
 
-    channels = color.coords()
+    channels = util.no_nan(color.coords())
     gamut = color._range
     fit = []
 
@@ -97,7 +97,7 @@ def clip(base, color):
 def norm_angles(color):
     """Normalize angles."""
 
-    channels = color.coords()
+    channels = util.no_nan(color.coords())
     gamut = color._range
     fit = []
     for i, value in enumerate(channels):
@@ -120,7 +120,7 @@ class Gamut:
         """Get coordinates within this space or fit to another space."""
 
         if method is None:
-            method = self.get_default("fit")
+            method = self.parent.FIT
 
         space = (self.space() if space is None else space).lower()
         method = self.space() if method is None else method
@@ -134,7 +134,7 @@ class Gamut:
         """Fit the gamut using the provided method."""
 
         if method is None:
-            method = self.get_default("fit")
+            method = self.parent.FIT
 
         this = self if in_place else self.clone()
 

--- a/coloraide/colors/_interpolate.py
+++ b/coloraide/colors/_interpolate.py
@@ -22,11 +22,11 @@ from . _range import Angle
 def overlay(c1, c2, a1, a2, a0):
     """Overlay one color channel over the other."""
 
-    if math.isnan(c1) and math.isnan(c2):
+    if util.is_nan(c1) and util.is_nan(c2):
         return 0.0
-    elif math.isnan(c1):
+    elif util.is_nan(c1):
         return c2 * a2
-    elif math.isnan(c2):
+    elif util.is_nan(c2):
         return c1 * a1
 
     c0 = c1 * a1 + c2 * a2 * (1 - a1)
@@ -39,11 +39,11 @@ def interpolate(p, coords1, coords2, create, progress, outspace, premultiplied):
     coords = []
     for i, c1 in enumerate(coords1):
         c2 = coords2[i]
-        if math.isnan(c1) and math.isnan(c2):
+        if util.is_nan(c1) and util.is_nan(c2):
             value = 0.0
-        elif math.isnan(c1):
+        elif util.is_nan(c1):
             value = c2
-        elif math.isnan(c2):
+        elif util.is_nan(c2):
             value = c1
         else:
             value = c1 + (c2 - c1) * (p if progress is None else progress(p))
@@ -63,17 +63,12 @@ def prepare_coords(color, adjust=None):
     then we need to set all other channels to NaN.
     """
 
-    if isinstance(color, Cylindrical):
-        if color.is_hue_null():
-            name = color.hue_name()
-            color.set(name, util.NAN)
-
     if adjust:
         to_adjust = adjust & color.CHANNEL_NAMES
         to_avoid = color.CHANNEL_NAMES - adjust
         if to_adjust:
             for channel in to_avoid:
-                color.set(channel, util.NAN)
+                color.set(channel, util.NaN)
 
 
 def postdivide(color):
@@ -132,7 +127,7 @@ def adjust_hues(color1, color2, hue):
     c1 = c1 % 360
     c2 = c2 % 360
 
-    if math.isnan(c1) or math.isnan(c2):
+    if util.is_nan(c1) or util.is_nan(c2):
         color1.set(name, c1)
         color2.set(name, c2)
         return

--- a/coloraide/colors/_space.py
+++ b/coloraide/colors/_space.py
@@ -41,7 +41,7 @@ def split_channels(cls, color):
         diff = cls.NUM_COLOR_CHANNELS - len(channels)
         channels.extend([0.0] * diff)
     channels.append(alpha if alpha is not None else 1.0)
-    return channels
+    return cls.null_adjust(channels)
 
 
 class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut.Gamut, convert.Convert):
@@ -221,5 +221,5 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
                 (m.group(1) and m.group(1).lower() == cls.space())
             ) and (not fullmatch or m.end(0) == len(string))
         ):
-            return cls.null_adjust(split_channels(cls, m.group(2))), m.end(0)
+            return split_channels(cls, m.group(2)), m.end(0)
         return None, None

--- a/coloraide/colors/_space.py
+++ b/coloraide/colors/_space.py
@@ -94,8 +94,8 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
 
         return 'color({} {} / {})'.format(
             self.space(),
-            ' '.join([util.fmt_float(c, util.DEF_PREC) for c in self.coords()]),
-            util.fmt_float(self.alpha, util.DEF_PREC)
+            ' '.join([util.fmt_float(c, util.DEF_PREC) for c in util.no_nan(self.coords())]),
+            util.fmt_float(util.no_nan(self.alpha), util.DEF_PREC)
         )
 
     __str__ = __repr__
@@ -105,12 +105,7 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
 
         if not util.is_number(value):
             raise TypeError("Value should be a number not type '{}'".format(type(value)))
-        return float(value)
-
-    def get_default(self, name):
-        """Get default."""
-
-        return self.parent.get_default(name)
+        return float(value) if not util.is_nan(value) else value
 
     def coords(self):
         """Coordinates."""
@@ -153,6 +148,11 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
 
         self._alpha = util.clamp(self._handle_input(value), 0.0, 1.0)
 
+    def is_nan(self, name):
+        """Check if the channel is NaN."""
+
+        return util.is_nan(self.get(name))
+
     def set(self, name, value):  # noqa: A003
         """Set the given channel."""
 
@@ -170,13 +170,17 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
         return getattr(self, name)
 
     def to_string(
-        self, *, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs
+        self, *, alpha=None, precision=None, fit=True, **kwargs
     ):
         """Convert to CSS 'color' string: `color(space coords+ / alpha)`."""
 
-        alpha = alpha is not False and (alpha is True or self.alpha < 1.0)
+        if precision is None:
+            precision = self.parent.PRECISION
 
-        coords = self.fit_coords() if fit else self.coords()
+        a = util.no_nan(self.alpha)
+        alpha = alpha is not False and (alpha is True or a < 1.0)
+
+        coords = util.no_nan(self.fit_coords() if fit else self.coords())
         template = "color({} {} {} {} / {})" if alpha else "color({} {} {} {})"
         values = [
             util.fmt_float(coords[0], precision),
@@ -184,9 +188,15 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
             util.fmt_float(coords[2], precision)
         ]
         if alpha:
-            values.append(util.fmt_float(self.alpha, max(precision, util.DEF_PREC)))
+            values.append(util.fmt_float(a, max(precision, util.DEF_PREC)))
 
         return template.format(self.space(), *values)
+
+    @classmethod
+    def null_adjust(cls, coords):
+        """Process coordinates and adjust any channels to null/NaN if required."""
+
+        return coords
 
     @classmethod
     def translate_channel(cls, channel, value):
@@ -211,5 +221,5 @@ class Space(contrast.Contrast, interpolate.Interpolate, distance.Distance, gamut
                 (m.group(1) and m.group(1).lower() == cls.space())
             ) and (not fullmatch or m.end(0) == len(string))
         ):
-            return split_channels(cls, m.group(2)), m.end(0)
+            return cls.null_adjust(split_channels(cls, m.group(2))), m.end(0)
         return None, None

--- a/coloraide/colors/hsv.py
+++ b/coloraide/colors/hsv.py
@@ -90,12 +90,6 @@ class HSV(Cylindrical, Space):
         else:
             raise TypeError("Unexpected type '{}' received".format(type(color)))
 
-    def is_hue_null(self):
-        """Test if hue is null."""
-
-        h, s, v = self.coords()
-        return s < util.ACHROMATIC_THRESHOLD
-
     @property
     def hue(self):
         """Hue channel."""
@@ -133,6 +127,14 @@ class HSV(Cylindrical, Space):
         self._coords[2] = self._handle_input(value)
 
     @classmethod
+    def null_adjust(cls, coords):
+        """On color update."""
+
+        if coords[1] == 0:
+            coords[0] = util.NaN
+        return coords
+
+    @classmethod
     def translate_channel(cls, channel, value):
         """Translate channel string."""
 
@@ -144,11 +146,6 @@ class HSV(Cylindrical, Space):
             return parse.norm_alpha_channel(value)
         else:
             raise ValueError("Unexpected channel index of '{}'".format(channel))
-
-    def to_string(self, *, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs):
-        """To string."""
-
-        return super().to_string(alpha=alpha, precision=precision, fit=fit)
 
     @classmethod
     def _to_xyz(cls, hsv):

--- a/coloraide/colors/hwb.py
+++ b/coloraide/colors/hwb.py
@@ -75,12 +75,6 @@ class HWB(Cylindrical, Space):
         else:
             raise TypeError("Unexpected type '{}' received".format(type(color)))
 
-    def is_hue_null(self):
-        """Test if hue is null."""
-
-        h, w, b = self.coords()
-        return (w + b) > (100.0 - util.ACHROMATIC_THRESHOLD)
-
     @property
     def hue(self):
         """Hue channel."""
@@ -118,6 +112,14 @@ class HWB(Cylindrical, Space):
         self._coords[2] = self._handle_input(value)
 
     @classmethod
+    def null_adjust(cls, coords):
+        """On color update."""
+
+        if coords[1] + coords[2] >= 100:
+            coords[0] = util.NaN
+        return coords
+
+    @classmethod
     def translate_channel(cls, channel, value):
         """Translate channel string."""
 
@@ -129,11 +131,6 @@ class HWB(Cylindrical, Space):
             return parse.norm_alpha_channel(value)
         else:
             raise ValueError("Unexpected channel index of '{}'".format(channel))
-
-    def to_string(self, *, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs):
-        """To string."""
-
-        return super().to_string(alpha=alpha, precision=precision, fit=fit)
 
     @classmethod
     def _to_xyz(cls, hwb):

--- a/coloraide/colors/lab.py
+++ b/coloraide/colors/lab.py
@@ -137,11 +137,6 @@ class LAB(Space):
         else:
             raise ValueError("Unexpected channel index of '{}'".format(channel))
 
-    def to_string(self, *, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs):
-        """To string."""
-
-        return super().to_string(alpha=alpha, precision=precision, fit=fit)
-
     @classmethod
     def _to_xyz(cls, lab):
         """To XYZ."""

--- a/coloraide/colors/lch.py
+++ b/coloraide/colors/lch.py
@@ -21,9 +21,12 @@ def lab_to_lch(lab):
     c = math.sqrt(math.pow(a, 2) + math.pow(b, 2))
     h = math.atan2(b, a) * 180 / math.pi
 
-    # Algorithm is dependent on the actual value, but at the same time,
-    # we want to treat it as null. Cast the actual value as null to avoid
-    # messing things up in interpolation.
+    # This is not actually part of the conversion, but is a fix-up
+    # for conversion getting a bit chaotic in regards to hue when
+    # chroma approaches zero. This fix-up is intended to make at
+    # least colors in the sRGB range a bit more stable with conversion
+    # and yield a hue of zero. This minimally affects the overall output.
+    # If a 100% accurate result is desired, then we'd want to avoid doing this.
     if c < ACHROMATIC_THRESHOLD:
         h = util.NaN
 

--- a/coloraide/colors/srgb.py
+++ b/coloraide/colors/srgb.py
@@ -159,11 +159,6 @@ class SRGB(Space):
         else:
             raise ValueError("Unexpected channel index of '{}'".format(channel))
 
-    def to_string(self, *, options=None, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs):
-        """To string."""
-
-        return super().to_string(alpha=alpha, precision=precision, fit=fit)
-
     @classmethod
     def _to_xyz(cls, rgb):
         """SRGB to XYZ."""

--- a/coloraide/colors/xyz.py
+++ b/coloraide/colors/xyz.py
@@ -3,7 +3,6 @@ from ._space import Space, RE_DEFAULT_MATCH
 from ._gamut import GamutUnbound
 from . import _parse as parse
 from . import _convert as convert
-from .. import util
 import re
 
 
@@ -91,8 +90,3 @@ class XYZ(Space):
             return parse.norm_alpha_channel(value)
         else:
             raise ValueError("Unexpected channel index of '{}'".format(channel))
-
-    def to_string(self, *, options=None, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs):
-        """To string."""
-
-        return super().to_string(alpha=alpha, precision=precision, fit=fit)

--- a/coloraide/css/colors/hsl.py
+++ b/coloraide/css/colors/hsl.py
@@ -87,7 +87,7 @@ class HSL(generic.HSL):
                 channels.append(cls.translate_channel(-1, c))
         if len(channels) == 3:
             channels.append(1.0)
-        return channels
+        return cls.null_adjust(channels)
 
     @classmethod
     def match(cls, string, start=0, fullmatch=True):
@@ -98,5 +98,5 @@ class HSL(generic.HSL):
             return channels, end
         m = cls.MATCH.match(string, start)
         if m is not None and (not fullmatch or m.end(0) == len(string)):
-            return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
+            return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
         return None, None

--- a/coloraide/css/colors/hsl.py
+++ b/coloraide/css/colors/hsl.py
@@ -29,18 +29,21 @@ class HSL(generic.HSL):
         super().__init__(color)
 
     def to_string(
-        self, *, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs
+        self, *, alpha=None, precision=None, fit=True, **kwargs
     ):
         """Convert to CSS."""
 
         options = kwargs
         alpha = options.get("alpha")
+        if precision is None:
+            precision = self.parent.PRECISION
 
         if options.get("color"):
             return super().to_string(alpha=alpha, precision=precision, fit=fit, **kwargs)
 
-        alpha = alpha is not False and (alpha is True or self.alpha < 1.0)
-        coords = self.fit_coords() if fit else self.coords()
+        a = util.no_nan(self.alpha)
+        alpha = alpha is not False and (alpha is True or a < 1.0)
+        coords = util.no_nan(self.fit_coords() if fit else self.coords())
 
         if alpha:
             template = "hsla({}, {}%, {}%, {})" if options.get("comma") else "hsl({} {}% {}% / {})"
@@ -48,7 +51,7 @@ class HSL(generic.HSL):
                 util.fmt_float(coords[0], precision),
                 util.fmt_float(coords[1], precision),
                 util.fmt_float(coords[2], precision),
-                util.fmt_float(self.alpha, max(util.DEF_PREC, precision))
+                util.fmt_float(a, max(util.DEF_PREC, precision))
             )
         else:
             template = "hsl({}, {}%, {}%)" if options.get("comma") else "hsl({} {}% {}%)"
@@ -95,5 +98,5 @@ class HSL(generic.HSL):
             return channels, end
         m = cls.MATCH.match(string, start)
         if m is not None and (not fullmatch or m.end(0) == len(string)):
-            return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
+            return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
         return None, None

--- a/coloraide/css/colors/hwb.py
+++ b/coloraide/css/colors/hwb.py
@@ -29,16 +29,20 @@ class HWB(generic.HWB):
         super().__init__(color)
 
     def to_string(
-        self, *, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs
+        self, *, alpha=None, precision=None, fit=True, **kwargs
     ):
         """Convert to CSS."""
+
+        if precision is None:
+            precision = self.parent.PRECISION
 
         options = kwargs
         if options.get("color"):
             return super().to_string(alpha=alpha, precision=precision, fit=fit, **kwargs)
 
-        alpha = alpha is not False and (alpha is True or self.alpha < 1.0)
-        coords = self.fit_coords() if fit else self.coords()
+        a = util.no_nan(self.alpha)
+        alpha = alpha is not False and (alpha is True or a < 1.0)
+        coords = util.no_nan(self.fit_coords() if fit else self.coords())
 
         if alpha:
             template = "hwb({}, {}%, {}%, {})" if options.get("comma") else "hwb({} {}% {}% / {})"
@@ -93,5 +97,5 @@ class HWB(generic.HWB):
             return channels, end
         m = cls.MATCH.match(string, start)
         if m is not None and (not fullmatch or m.end(0) == len(string)):
-            return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
+            return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
         return None, None

--- a/coloraide/css/colors/hwb.py
+++ b/coloraide/css/colors/hwb.py
@@ -86,7 +86,7 @@ class HWB(generic.HWB):
                 channels.append(cls.translate_channel(-1, c))
         if len(channels) == 3:
             channels.append(1.0)
-        return channels
+        return cls.null_adjust(channels)
 
     @classmethod
     def match(cls, string, start=0, fullmatch=True):
@@ -97,5 +97,5 @@ class HWB(generic.HWB):
             return channels, end
         m = cls.MATCH.match(string, start)
         if m is not None and (not fullmatch or m.end(0) == len(string)):
-            return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
+            return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
         return None, None

--- a/coloraide/css/colors/lab.py
+++ b/coloraide/css/colors/lab.py
@@ -31,16 +31,20 @@ class LAB(generic.LAB):
         super().__init__(color)
 
     def to_string(
-        self, *, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs
+        self, *, alpha=None, precision=None, fit=True, **kwargs
     ):
         """Convert to CSS."""
+
+        if precision is None:
+            precision = self.parent.PRECISION
 
         options = kwargs
         if options.get("color"):
             return super().to_string(alpha=alpha, precision=precision, fit=fit, **kwargs)
 
-        alpha = alpha is not False and (alpha is True or self.alpha < 1.0)
-        coords = self.fit_coords() if fit else self.coords()
+        a = util.no_nan(self.alpha)
+        alpha = alpha is not False and (alpha is True or a < 1.0)
+        coords = util.no_nan(self.fit_coords() if fit else self.coords())
 
         if alpha:
             template = "lab({}%, {}, {}, {})" if options.get("comma") else "lab({}% {} {} / {})"
@@ -48,7 +52,7 @@ class LAB(generic.LAB):
                 util.fmt_float(coords[0], precision),
                 util.fmt_float(coords[1], precision),
                 util.fmt_float(coords[2], precision),
-                util.fmt_float(self.alpha, max(util.DEF_PREC, precision))
+                util.fmt_float(a, max(util.DEF_PREC, precision))
             )
         else:
             template = "lab({}%, {}, {})" if options.get("comma") else "lab({}% {} {})"
@@ -95,5 +99,5 @@ class LAB(generic.LAB):
             return channels, end
         m = cls.MATCH.match(string, start)
         if m is not None and (not fullmatch or m.end(0) == len(string)):
-            return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
+            return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
         return None, None

--- a/coloraide/css/colors/lab.py
+++ b/coloraide/css/colors/lab.py
@@ -88,7 +88,7 @@ class LAB(generic.LAB):
                 channels.append(cls.translate_channel(-1, c))
         if len(channels) == 3:
             channels.append(1.0)
-        return channels
+        return cls.null_adjust(channels)
 
     @classmethod
     def match(cls, string, start=0, fullmatch=True):
@@ -99,5 +99,5 @@ class LAB(generic.LAB):
             return channels, end
         m = cls.MATCH.match(string, start)
         if m is not None and (not fullmatch or m.end(0) == len(string)):
-            return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
+            return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
         return None, None

--- a/coloraide/css/colors/lch.py
+++ b/coloraide/css/colors/lch.py
@@ -29,16 +29,20 @@ class LCH(generic.LCH):
         super().__init__(color)
 
     def to_string(
-        self, *, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs
+        self, *, alpha=None, precision=None, fit=True, **kwargs
     ):
         """Convert to CSS."""
+
+        if precision is None:
+            precision = self.parent.PRECISION
 
         options = kwargs
         if options.get("color"):
             return super().to_string(alpha=alpha, precision=precision, fit=fit, **kwargs)
 
-        alpha = alpha is not False and (alpha is True or self.alpha < 1.0)
-        coords = self.fit_coords() if fit else self.coords()
+        a = util.no_nan(self.alpha)
+        alpha = alpha is not False and (alpha is True or a < 1.0)
+        coords = util.no_nan(self.fit_coords() if fit else self.coords())
 
         if alpha:
             template = "lch({}%, {}, {}, {})" if options.get("comma") else "lch({}% {} {} / {})"
@@ -46,7 +50,7 @@ class LCH(generic.LCH):
                 util.fmt_float(coords[0], precision),
                 util.fmt_float(coords[1], precision),
                 util.fmt_float(coords[2], precision),
-                util.fmt_float(self.alpha, max(util.DEF_PREC, precision))
+                util.fmt_float(a, max(util.DEF_PREC, precision))
             )
         else:
             template = "lch({}%, {}, {})" if options.get("comma") else "lch({}% {} {})"
@@ -95,5 +99,5 @@ class LCH(generic.LCH):
             return channels, end
         m = cls.MATCH.match(string, start)
         if m is not None and (not fullmatch or m.end(0) == len(string)):
-            return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
+            return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
         return None, None

--- a/coloraide/css/colors/lch.py
+++ b/coloraide/css/colors/lch.py
@@ -88,7 +88,7 @@ class LCH(generic.LCH):
                 channels.append(cls.translate_channel(-1, c))
         if len(channels) == 3:
             channels.append(1.0)
-        return channels
+        return cls.null_adjust(channels)
 
     @classmethod
     def match(cls, string, start=0, fullmatch=True):
@@ -99,5 +99,5 @@ class LCH(generic.LCH):
             return channels, end
         m = cls.MATCH.match(string, start)
         if m is not None and (not fullmatch or m.end(0) == len(string)):
-            return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
+            return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
         return None, None

--- a/coloraide/css/colors/srgb.py
+++ b/coloraide/css/colors/srgb.py
@@ -174,23 +174,27 @@ class SRGB(generic.SRGB):
                     channels.append(cls.translate_channel(-1, c))
             if len(channels) == 3:
                 channels.append(1.0)
-            return channels
+            return cls.null_adjust(channels)
         else:
             m = cls.HEX_MATCH.match(color)
             assert(m is not None)
             if m.group(1):
-                return (
-                    cls.translate_channel(0, "#" + color[1:3]),
-                    cls.translate_channel(1, "#" + color[3:5]),
-                    cls.translate_channel(2, "#" + color[5:7]),
-                    cls.translate_channel(-1, "#" + m.group(2)) if m.group(2) else 1.0
+                return cls.null_adjust(
+                    (
+                        cls.translate_channel(0, "#" + color[1:3]),
+                        cls.translate_channel(1, "#" + color[3:5]),
+                        cls.translate_channel(2, "#" + color[5:7]),
+                        cls.translate_channel(-1, "#" + m.group(2)) if m.group(2) else 1.0
+                    )
                 )
             else:
-                return (
-                    cls.translate_channel(0, "#" + color[1] * 2),
-                    cls.translate_channel(1, "#" + color[2] * 2),
-                    cls.translate_channel(2, "#" + color[3] * 2),
-                    cls.translate_channel(-1, "#" + m.group(4)) if m.group(4) else 1.0
+                return cls.null_adjust(
+                    (
+                        cls.translate_channel(0, "#" + color[1] * 2),
+                        cls.translate_channel(1, "#" + color[2] * 2),
+                        cls.translate_channel(2, "#" + color[3] * 2),
+                        cls.translate_channel(-1, "#" + m.group(4)) if m.group(4) else 1.0
+                    )
                 )
 
     @classmethod
@@ -205,7 +209,7 @@ class SRGB(generic.SRGB):
             if not string[start:start + 5].lower().startswith(('#', 'rgb(', 'rgba(')):
                 string = css_names.name2hex(string[m.start(0):m.end(0)])
                 if string is not None:
-                    return cls.null_adjust(cls.split_channels(string)), m.end(0)
+                    return cls.split_channels(string), m.end(0)
             else:
-                return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
+                return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
         return None, None

--- a/coloraide/css/colors/srgb.py
+++ b/coloraide/css/colors/srgb.py
@@ -51,9 +51,12 @@ class SRGB(generic.SRGB):
         super().__init__(color)
 
     def to_string(
-        self, *, alpha=None, precision=util.DEF_PREC, fit=True, **kwargs
+        self, *, alpha=None, precision=None, fit=True, **kwargs
     ):
         """Convert to CSS."""
+
+        if precision is None:
+            precision = self.parent.PRECISION
 
         options = kwargs
         if options.get("color"):
@@ -61,7 +64,8 @@ class SRGB(generic.SRGB):
 
         # Handle hes and color names
         value = ''
-        alpha = alpha is not False and (alpha is True or self.alpha < 1.0)
+        a = util.no_nan(self.alpha)
+        alpha = alpha is not False and (alpha is True or a < 1.0)
         if options.get("hex") or options.get("names"):
             h = self._get_hex(options, alpha=alpha, precision=precision)
             if options.get("hex"):
@@ -80,7 +84,7 @@ class SRGB(generic.SRGB):
             percent = options.get("percent", False)
             comma = options.get("comma", False)
             factor = 100.0 if percent else 255.0
-            coords = self.fit_coords() if fit else self.coords()
+            coords = util.no_nan(self.fit_coords() if fit else self.coords())
 
             if alpha:
                 if percent:
@@ -91,7 +95,7 @@ class SRGB(generic.SRGB):
                     util.fmt_float(coords[0] * factor, precision),
                     util.fmt_float(coords[1] * factor, precision),
                     util.fmt_float(coords[2] * factor, precision),
-                    util.fmt_float(self.alpha, max(util.DEF_PREC, precision))
+                    util.fmt_float(a, max(util.DEF_PREC, precision))
                 )
             else:
                 if percent:
@@ -105,12 +109,15 @@ class SRGB(generic.SRGB):
                 )
         return value
 
-    def _get_hex(self, options, *, alpha=False, precision=util.DEF_PREC):
+    def _get_hex(self, options, *, alpha=False, precision=None):
         """Get the hex `RGB` value."""
+
+        if precision is None:
+            precision = self.parent.PRECISION
 
         hex_upper = options.get("hex_upper", False)
         compress = options.get("compress", False)
-        coords = self.fit_coords()
+        coords = util.no_nan(self.fit_coords())
 
         template = "#{:02x}{:02x}{:02x}{:02x}" if alpha else "#{:02x}{:02x}{:02x}"
         if hex_upper:
@@ -121,7 +128,7 @@ class SRGB(generic.SRGB):
                 int(util.round_half_up(coords[0] * 255.0)),
                 int(util.round_half_up(coords[1] * 255.0)),
                 int(util.round_half_up(coords[2] * 255.0)),
-                int(util.round_half_up(self.alpha * 255.0))
+                int(util.round_half_up(util.no_nan(self.alpha) * 255.0))
             )
         else:
             value = template.format(
@@ -198,7 +205,7 @@ class SRGB(generic.SRGB):
             if not string[start:start + 5].lower().startswith(('#', 'rgb(', 'rgba(')):
                 string = css_names.name2hex(string[m.start(0):m.end(0)])
                 if string is not None:
-                    return cls.split_channels(string), m.end(0)
+                    return cls.null_adjust(cls.split_channels(string)), m.end(0)
             else:
-                return cls.split_channels(string[m.start(0):m.end(0)]), m.end(0)
+                return cls.null_adjust(cls.split_channels(string[m.start(0):m.end(0)])), m.end(0)
         return None, None

--- a/coloraide/util.py
+++ b/coloraide/util.py
@@ -5,7 +5,7 @@ import numbers
 import re
 
 RE_FLOAT_TRIM = re.compile(r'^(?P<keep>-?\d+)(?P<trash>\.0+|(?P<keep2>\.\d*[1-9])0+)$')
-NAN = float('nan')
+NaN = float('nan')
 INF = float('inf')
 ACHROMATIC_THRESHOLD = 0.0005
 DEF_PREC = 5
@@ -14,12 +14,29 @@ DEF_ALPHA = 1.0
 DEF_MIX = 0.5
 DEF_HUE_ADJ = "shorter"
 DEF_DISTANCE_SPACE = "lab"
+DEF_FIT = "lch-chroma"
+DEF_DELTA_E = "76"
 
 
 def is_number(value):
     """Check if value is a number."""
 
     return isinstance(value, numbers.Number)
+
+
+def is_nan(value):
+    """Print is "not a number"."""
+
+    return math.isnan(value)
+
+
+def no_nan(value):
+    """Convert list of numbers or single number to valid numbers."""
+
+    if is_number(value):
+        return 0.0 if is_nan(value) else value
+    else:
+        return [(0.0 if is_nan(x) else x) for x in value]
 
 
 def dot(a, b):

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -35,6 +35,7 @@ Twemoji
 Verou
 XYZ
 accessor
+accessors
 boolean
 chroma
 fixup

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.0a4
+
+- **NEW**: Use `NaN` to track undefined hues.
+- **NEW**: Remove `is_hue_null` and add new API function `is_nan` to test if any channel is currently set to `NaN`.
+- **NEW**: Remove `get_default` from the `Color` class and instead allow properties that can be overridden when
+  subclassing the `Color` object.
+
 ## 0.1.0a3
 
 - **FIX**: Color object API was missing the ability to receive the `premultiplied` argument.

--- a/docs/src/markdown/api/index.md
+++ b/docs/src/markdown/api/index.md
@@ -464,53 +464,25 @@ Parameters
     `name`     |                    | Channel name or color space and channel name to retrieve value from.
     `value`    |                    | A numerical value, a string value accepted by the specified color space, or a function.
 
-### `is_hue_null`
+### `is_nan`
 
 ```py3
-def is_hue_null(self, space=None):
+def is_nan(self, name):
 ```
 
-If the current color space is cylindrical, this will return whether the hue is considered null based on the color
-space's criteria for null hues. A different color space can be provided via `space` to check the hue in a different
-color space.
-
-If the color space being evaluated is not cylindrical, `#!py3 False` will be returned.
+Retrieves the coordinate value from the specified channel and checks whether the value is `NaN`. Channel must be a
+channel name in the current color space or a channel name in the specified color space using the syntax:
+`space.channel`.
 
 Return
 : 
-    Returns a boolean indicating whether the specified color space's hue is null. If the color space does not have a hue
-    channel, `#!py3 False` will be returned.
+    Returns a boolean indicating whether the specified color space's channel is `NaN`.
 
 Parameters
 : 
     Parameters | Defaults           | Description
     ---------- | ------------------ | -----------
-    `space`    | `#!py3 None`       | A string indicating what color space the hue should be evaluated in. If `#!py3 None`, the current color space will be used.
-
-
-### `get_default`
-
-```py3
-def get_default(self, name):
-```
-
-While mainly used internally, `get_default` exposes access to the certain default settings. Currently only `fit` and
-`delta-e` are exposed here.
-
-Name      | Description
---------- | -----------
-`fit`     | The default gamut mapping method used by the [`Color`](#color) object.
-`delta-e` | The default delta E algorithm used for gamut distancing calls internally.
-
-Return
-: 
-    Returns the default value of the requested default option.
-
-Parameters
-: 
-    Parameters | Defaults           | Description
-    ---------- | ------------------ | -----------
-    `name`     |                    | Name of default option to access.
+    `name`     |                    | A string indicating what channel property to check.
 
 ### Dynamic Channel Properties
 

--- a/docs/src/markdown/api/index.md
+++ b/docs/src/markdown/api/index.md
@@ -27,8 +27,11 @@ def match(cls, string, start=0, fullmatch=False, *, filters=None):
 ```
 
 The `match` class method provides access to the color matching interface and allows a user to provide a color string
-and get back a `ColorMatch` object which contains a `Color` object and the bounds within the string where the color
-was found.
+and get back a `ColorMatch` object. `ColorMatch` objects contain three properties:
+
+1. `color`: the `Color` object.
+2. `start`: the starting point within the string buffer where the color was found.
+3. `end`: the ending point within the string buffer where the color was found.
 
 Match does not search the entire buffer, but simply matches at the location specified by `start`.
 
@@ -89,7 +92,7 @@ def update(self, color, data=None, alpha=util.DEF_ALPHA, *, filters=None, **kwar
 
 The `update` method provides a way to update the underlying color spaces with coordinates from any color space. The
 methods signature looks just like [`new`](#new) and accepts color strings, `Color` objects, or raw data points specified
-with a color space string and coordinates. The object itself will be updated and remain in it's current color space.
+with a color space string and coordinates. The object itself will be updated and remain in its current color space.
 
 Return
 : 
@@ -111,8 +114,8 @@ Parameters
 def mutate(self, color, data=None, alpha=util.DEF_ALPHA, *, filters=None, **kwargs):
 ```
 
-The `mutate` method is just like [`update`](#update) except that it will provide an update, but mutate the color space
-to match the color space of the provided color input.
+The `mutate` method is just like [`update`](#update) except that it will not only update the color space, but mutate it
+to the provided color space.
 
 Return
 : 
@@ -145,7 +148,8 @@ Return
 def coords(self):
 ```
 
-Returns a list of the color's coordinates. This does **not** include the alpha channel.
+Returns a list of the color's coordinates. This does **not** include the alpha channel. Alpha can be accessed via the
+`alpha` property or `get` and `set` accessors.
 
 Return
 : 
@@ -300,8 +304,8 @@ def interpolate(self, color, *, space="lab", progress=None, out_space=None, adju
 The `interpolate` method creates a function that takes a value between 0 - 1 and interpolates a new color based on the
 input value.
 
-Interpolation can be customized by limiting to specific color channels, providing custom interpolation functions, and
-even adjusting the hue logic used.
+Interpolation can be customized by limiting the interpolation to specific color channels, providing custom interpolation
+functions, and even adjusting the hue logic used.
 
 Hue\ Evaluation | Description
 --------------- | -----------
@@ -329,9 +333,10 @@ Parameters
 def steps(self, color, *, steps=2, max_steps=1000, max_delta_e=0, **interpolate_args):
 ```
 
-Creates an interpolate function and iterates through with user defined step parameters to produce discrete color steps.
-Will attempt to provide the minimum number of `steps` without exceeding `max_steps`. If `max_delta_e` the distance between
-each stop will be cut in half until there are no colors with a distance greater than the specified `max_delta_e`.
+Creates an `interpolate` function and iterates through it with user defined step parameters to produce discrete color
+steps. Will attempt to provide the minimum number of `steps` without exceeding `max_steps`. If `max_delta_e` is provided,
+the distance between each stop will be cut in half until there are no colors with a distance greater than the specified
+`max_delta_e`.
 
 Return
 : 

--- a/docs/src/markdown/color.md
+++ b/docs/src/markdown/color.md
@@ -183,3 +183,27 @@ or color names that are part of color variables (`#!css var(--color-red)`).
     Found rgb(255 0 51) @ index 34
     Found lch(90% 50 50) @ index 46
     ```
+
+## Override Default Settings
+
+ColorAide has a couple of default settings, such as the default precision for string outputs, default gamut mapping
+mode, etc. All of these options can be set on-demand when calling certain functions. When not explicitly set, some
+default is used. If needed, the defaults can be changed for an entire application or library. To do so, simply subclass
+the `Color` object and override the defaults. Then the new derived class can be used throughout an application or
+library.
+
+```pycon3
+>>> Color('red').convert('lch').to_string()
+'lch(54.288% 106.83 40.853)'
+>>> class Color2(Color):
+...     PRECISION = 3
+...
+>>> Color2('red').convert('lch').to_string()
+'lch(54.3% 107 40.9)'
+```
+
+Properties  | Description
+----------- | -----------
+`FIT`       | The default gamut mapping method used by the [`Color`](#color) object.
+`DELTA_E`   | The default delta E algorithm used for gamut distancing calls internally.
+`PRECISION` | The default precision for string outputs.

--- a/docs/src/markdown/color.md
+++ b/docs/src/markdown/color.md
@@ -36,7 +36,7 @@ So in the example above, the raw data is parsed, and we get a transparent color 
 We can also pass in other color objects, which is really only useful if we've subclassed the `Color` object and want
 to cast the object between the classes.
 
-The same color creation can be preformed from a color's `new` class method as well. New accepts the same inputs
+The same color creation can be preformed from a color's `new` class method as well. `new` accepts the same inputs
 as the class object itself.
 
 ```pycon3
@@ -102,7 +102,7 @@ color(lch 50 50 130 / 1)
 ## Converting
 
 Colors can be converted to other color spaces as needed. Converting will always return a new color unless `in_place` is
-set `True`.
+set `True`, in which case the current color will be mutated to the new converted color.
 
 For instance, if we had a color `#!color yellow`, and we needed to work with it in another color space, we
 could simply call the `convert` method. In the example below, we convert the color `#!color yellow`, which is in the
@@ -115,9 +115,9 @@ color(lab 97.607 -15.753 93.388 / 1)
 
 ## Color Matching
 
-Color objects can take in raw data points with a color space name or CSS style inputs. This CSS style input logic is
-exposed via the `match` method. By default, we can just give it a string, and it will return a `ColorMatch` object. The
-`ColorMatch` object will have the matched color as a `Color` object, and the start and end points it was located at.
+Color objects can take in raw data points or a CSS style string input. The string matching logic is exposed via the
+`match` method. By default, we can just give it a string, and it will return a `ColorMatch` object. The `ColorMatch`
+object will have the matched color as a `Color` object, and the `start` and `end` points it was located at.
 
 ```pycon3
 >>> Color.match("red")

--- a/docs/src/markdown/contrast.md
+++ b/docs/src/markdown/contrast.md
@@ -2,8 +2,7 @@
 
 ## Relative Luminance
 
-ColorAide provides a couple of contrast related tools out of the box. Relative luminance is used to calculate the
-contrast ratio. To get the luminance, simply call the `luminance` method:
+Relative luminance is used to calculate the contrast ratio. To get the luminance, simply call the `luminance` method:
 
 ```pycon3
 >>> Color("black").luminance()

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -1,5 +1,9 @@
 # Setup
 
+!!! warning "Currently in Alpha"
+    While ColorAide is very usable, it is currently in an alpha stage. While that doesn't necessarily mean been buggy,
+    it does mean the API could be unstable.
+
 ## Overview
 
 ColorAide is a color library for Python. It was written to handle most modern CSS colors that are available and that
@@ -7,14 +11,10 @@ will be available. Most of the conversion algorithms come straight from the [CSS
 
 In the process of developing this library, we also stumbled upon [Color.js][colorjs] which is created/maintained by the
 co-authors of some of the recent CSS color specifications. This project became heavily influenced by Color.js. While our
-aim was not to port that library, it did leave a clear impression on our API. We also leveraged the work related to
-gamut mapping and color interpolation.
+aim was not to port that library, it did leave a clear impression on our API.
 
-Currently this project is in an early stage, and while usable, some things may change as we get closer to a stable
-release.
-
-With ColorAide, colors in various spaces can be created, converted to other spaces, mixed, output in different CSS
-formats, and various other things.
+With ColorAide, colors in various spaces can be created, converted to other spaces, mixed, manipulated, and output in
+different CSS formats.
 
 ```pycon3
 >>> from coloraide import Color

--- a/docs/src/markdown/interpolation.md
+++ b/docs/src/markdown/interpolation.md
@@ -228,7 +228,7 @@ yields the color: `#!color rgb(127.5 0 0)`.
 
 A new color will be returned instead of modifying the current color unless `in_place` is set `True`.
 
-## Null Hues
+## Null Handling
 
 Color spaces that have hue coordinates often have rules about when the hue is considered relevant. For instance, in the
 HSL color space, if saturation is zero, the hue is considered null. This is because the color is "without color";
@@ -261,10 +261,10 @@ color(hsl 300 50 62.549 / 1)
 ```
 
 This is essentially haw the `adjust` parameter works with [`interploate`](#interpolate), [`step`](#step), and
-[`mix`](#mix), except it will set the channel on both colors to `NaN`.
+[`mix`](#mix). `adjust` simply ensures that the secondary color has `NaN` set to specified channels.
 
-Technically, any channel can be set to `Nan`, but it must be done by instantiating a `Color` object with raw data or by
-manually setting it via a channel property or accessor.
+Technically, any channel can be set to `NaN`, but it must be done by instantiating a `Color` object with raw data or by
+manually setting it via a channel property or accessor. CSS string inputs do not allow the `NaN` value.
 
 ```pycon3
 >>> from coloraide import Color, NaN

--- a/docs/src/markdown/interpolation.md
+++ b/docs/src/markdown/interpolation.md
@@ -241,42 +241,62 @@ that are above and beyond the normal rules to help ensure good interpolation. Fo
 on HSL colors when saturation is zero, but also when lightness is zero or one hundred (essentially appearing black or
 white). In fact, they'll mark saturation as `NaN` when lightness indicates "black" or "white".
 
-ColorAide also uses `NaN` during interpolating, but we do not carry that baggage around outside of interpolating.
-Colors will not return `NaN` in their coordinates, so the user doesn't have to worry about checking for those cases when
-assigning values, but it will calculate when hues are null when doing interpolation. If a space needs to account for hue
-when interpolating (mainly cylindrical color spaces) then ColorAide will flag the hue channel as null by assigning the
-coordinate a `NaN` prior to the actual interpolation.
+ColorAide also uses `NaN`, or in Python `#!py3 float('nan')`. In certain situations, when a hue is deemed undefined, the
+hue value will be set to `coloraide.NaN`, which is just a constant containing `#!py3 float('nan')`. When interpolating,
+if one color's channel has a `NaN`, the other color's channel will be used as the result. If both colors have a `NaN`
+for the same channel, then `0` will be returned.
 
-ColorAide will consider the following color spaces as having a null hue in the following cases. For "very near" cases,
-the threshold noted in the table is used. LCH uses a much larger threshold as conversions are more unstable as zero is
-approached.
-
-Color\ Space | Null\ Condition                   | Nearness\ Threshold
------------- | --------------------------------- | -------------------
-HSV          | `s<=0` or very near 0             | `0.0005`
-HSL          | `s<=0` or very near 0%            | `0.0005`
-HWB          | `(w + b) >= 100`or very near 100% | `0.0005`
-LCH          | `c<=0` or very near 0%            | `0.015`
-
-To determine at any time if a hue is considered null, the `is_hue_null` method can be used. Any space that considers
-hue will return `True` or `False` if their hue is null or not. Any space that does not specifically calculate hue, will
-simply return `False`. The method will consider the current color space by default, but we can query any color spaces by
-providing a different one.
+Notice that in this example, because white's saturation is zero, the hue is undefined. Because the hue is undefined,
+when the color is mixed with a second color (`#!color purple`), the hue of the second color is used.
 
 ```pycon3
->>> Color("hsl(0 0% 50%)").is_hue_null()
-True
->>> Color("grey").is_hue_null("lch")
-True
->>> Color("grey").is_hue_null("hsl")
-True
->>> Color("grey").is_hue_null("hsv")
-True
->>> Color("grey").is_hue_null("hwb")
-True
->>> Color("grey").is_hue_null("lab")
-False
+>>> color = Color('white').convert('hsl')
+>>> color.coords()
+[nan, 0.0, 100.0]
+>>> color2 = Color('purple').convert('hsl')
+>>> color2.coords()
+[300.0, 100.0, 25.098039215686274]
+>>> color.mix(color2, space="hsl")
+color(hsl 300 50 62.549 / 1)
 ```
 
-Due to the way colors convert, all spaces may not yield the same value as they do in this example, so it is best to test
-in the space that is being targeted.
+This is essentially haw the `adjust` parameter works with [`interploate`](#interpolate), [`step`](#step), and
+[`mix`](#mix), except it will set the channel on both colors to `NaN`.
+
+Technically, any channel can be set to `Nan`, but it must be done by instantiating a `Color` object with raw data or by
+manually setting it via a channel property or accessor.
+
+```pycon3
+>>> from coloraide import Color, NaN
+>>> Color("srgb", [1, NaN, 1]).coords()
+[1.0, nan, 1.0]
+>>> Color("red").set('green', NaN).coords()
+[1.0, nan, 0.0]
+```
+
+When printing to a string, `NaN`s are always converted to `0`:
+
+```pycon3
+>>> Color("srgb", [1, NaN, 1])
+color(srgb 1 0 1 / 1)
+```
+
+At any time, a channel can be checked for whether it is `NaN` by using the `is_nan` method:
+
+```pycon3
+>>> Color("white").convert('hsl').is_nan('hue')
+>>> True
+```
+
+It can be useful to check whether a channel is `NaN` as `NaN` values can't be added, subtracted, multiplied, etc. They
+will always return `NaN` unless you directly replace them.
+
+```pycon3
+>>> color = Color("white").convert('hsl')
+>>> color.hue = color.hue + 3
+>>> color.is_nan('hue')
+True
+>>> color.hue = 3
+>>> color.is_nan('hue')
+False
+```

--- a/docs/src/markdown/manipulation.md
+++ b/docs/src/markdown/manipulation.md
@@ -80,3 +80,37 @@ transform the color `#!color pink` to `#!color rgb(255 249.6 203)`.
 >>> Color("pink").set('green', lambda g: g * 1.3).to_string()
 'rgb(255 249.6 203)'
 ```
+
+## Checking Null Hues
+
+Cylindrical colors that offer a `hue` property can sometimes return `NaN` for a hue. This is usually because the hue
+is undefined. For example, the color `#!color hsl(360, 0% 100%)`, while assigned a hue, does not actually exhibit any
+real hue since saturation is 0. Essentially, hue could be set to anything, and it would still have no affect on the
+actual color. So, ColorAide will actually set hue to `NaN` (or "not a number"). `NaN` is treated as a zero on output.
+
+```pycon3
+>>> color = Color('hsl(360 0% 100%)')
+>>> color
+color(hsl 0 0 100 / 1)
+>>> color.coords()
+[nan, 0.0, 100.0]
+```
+
+Because `NaN` are not numbers, these values will not be included in color interpolation, and these values cannot be
+added, multiplied, or take part in any real math operations. All math operations performed on `NaN` simply return `NaN`.
+
+For this reason, it is useful to check if a hue is `NaN`. This can be done with the `is_nan` function. You can simply
+give `is_nan` the property you wish to check, and it will return either `#!py3 True` or `#!py3 False`.
+
+```pycon3
+>>> Color('hsl(360 0% 100%)').is_nan('hue')
+True
+```
+
+This is equivalent to using the `math` library and comparing the value directly:
+
+```pycon3
+>>> import math
+>>> math.isnan(Color('hsl(360 0% 100%)').hue)
+True
+```

--- a/docs/src/markdown/strings.md
+++ b/docs/src/markdown/strings.md
@@ -1,7 +1,7 @@
 ## Convert to Strings
 
-Colors can be translated to strings by using the `to_string` method. The CSS color class will convert the current color
-into one of many of the color's CSS formats.
+Colors can be translated to strings by using the `to_string` method. The color class will convert the current color into
+one of many of the color's CSS formats.
 
 ```pycon3
 >>> color = Color("srgb", [0.5, 0, 1], 0.3)

--- a/docs/theme/colorswatch.css
+++ b/docs/theme/colorswatch.css
@@ -66,12 +66,10 @@
 
 span.swatch:not(.swatch-gradient):hover {
   z-index: 2;
-  transform: scale(1.7);
-  translateY(10%);
+  transform: scale(1.7) translateY(5%);
 }
 
 span.swatch.swatch-gradient:hover {
   z-index: 2;
-  transform: scale(1.3);
-  translateY(10%);
+  transform: scale(1.3) translateY(5%);
 }


### PR DESCRIPTION
- Use `NaN` to track undefined hues.
- Remove `is_hue_null` and add new API function `is_nan` to test if any
  channel is currently set to `NaN`.
- Remove `get_default` from the `Color` class.
- Add back the lCH fix-up that colorjs.io uses (setting hue to `NaN` if chroma is below 0.02). This helps with the chaotic conversion in relation to hues for colors in the sRGB range. Yes the conversion is technically less accurate, but conversions between sRGB and LCH is a little more sane. Plotting it out it really does seem to cutoff at the sRGB range.

I tried to avoid adding `NaN` support for quite a bit, but I've decided to cave. Most people are used this mentality when using color libs like this, and it does give more control, even if it adds some more complexity to account for `NaN`s in the code. It also adds a slight burden to users if they must check for these too, but overall, it probably makes it easier to handle things.