### PR TITLE
Make some adjustments to conversions for HWB and HSV

### DIFF
--- a/coloraide/__meta__.py
+++ b/coloraide/__meta__.py
@@ -188,5 +188,5 @@ def parse_version(ver):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(0, 1, 0, "alpha", 12)
+__version_info__ = Version(0, 1, 0, "alpha", 13)
 __version__ = __version_info__._get_canonical()

--- a/coloraide/colors/hsv.py
+++ b/coloraide/colors/hsv.py
@@ -22,10 +22,14 @@ def hsv_to_hsl(hsv):
     s /= 100.0
     v /= 100.0
     l = v * (1.0 - s / 2.0)
+    s = 0.0 if (l == 0.0 or l == 1.0) else ((v - l) / min(l, 1.0 - l)) * 100
+
+    if s == 0:
+        h = util.NaN
 
     return [
         HSV._constrain_hue(h),
-        0.0 if (l == 0.0 or l == 1.0) else ((v - l) / min(l, 1.0 - l)) * 100,
+        s,
         l * 100
     ]
 
@@ -42,12 +46,12 @@ def hsl_to_hsv(hsl):
     l /= 100.0
 
     v = l + s * min(l, 1.0 - l)
+    s = 0.0 if (v == 0.0) else 2 * (1.0 - l / v)
 
-    return [
-        HSV._constrain_hue(h),
-        0.0 if (v == 0.0) else 200.0 * (1.0 - l / v),
-        100.0 * v
-    ]
+    if s == 0:
+        h = util.NaN
+
+    return [HSV._constrain_hue(h), s * 100.0, v * 100.0]
 
 
 class HSV(Cylindrical, Space):

--- a/coloraide/colors/hwb.py
+++ b/coloraide/colors/hwb.py
@@ -1,7 +1,6 @@
 """HWB class."""
 from ._space import Space, RE_DEFAULT_MATCH
 from .srgb import SRGB
-from .hsl import HSL
 from .hsv import HSV
 from ._cylindrical import Cylindrical
 from ._gamut import GamutBound
@@ -19,10 +18,10 @@ def hwb_to_hsv(hwb):
     w /= 100.0
     b /= 100.0
 
-    wb = w + b;
+    wb = w + b
     if (wb >= 1):
-         gray = w / wb
-         return [util.NaN, 0.0, gray * 100.0]
+        gray = w / wb
+        return [util.NaN, 0.0, gray * 100.0]
 
     v = 1 - b
     s = 0 if v == 0 else 1 - w / v

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.0a13
+
+- **FIX**: HSV did not always set hue to `NaN` when saturation was `0`.
+- **FIX**: Give better conversion results by having HWB colors pass through HSV instead of sRGB.
+
 ## 0.1.0a12
 
 - **FIX**: More stable saturation calculation for HSL to ensure divide by zero doesn't occur.


### PR DESCRIPTION
1. Ensure HSV always sets NaN when needed as there were times it did not
2. Instead of sending HWB conversions through sRGB, send conversions
   through HSV which gives cleaner results.