### PR TITLE
Fix typo in gamut mapping docs

### DIFF
--- a/coloraide/color/gamut/lch_chroma.py
+++ b/coloraide/color/gamut/lch_chroma.py
@@ -10,7 +10,7 @@ def fit(color):
     Algorithm originally came from https://colorjs.io/docs/gamut-mapping.html.
     Some things have been optimized and fixed though to better perform as intended.
 
-    The idea is to hold hue and lightness constant and decrease lightness until
+    The idea is to hold hue and lightness constant and decrease chroma until
     color comes under gamut.
 
     We'll use a binary search and at after each stage, we will clip the color


### PR DESCRIPTION
As shown in both the code and the original implementation of this gamut mapping algorithm in Color.js, it reduces chroma, not lightness.