### PR TITLE
Better playground experience

### DIFF
--- a/docs/src/markdown/.snippets/playground.txt
+++ b/docs/src/markdown/.snippets/playground.txt
@@ -8,6 +8,7 @@ Transform Python code by executing it, transforming to a Python console output,
 and finding and outputting color previews.
 """
 import micropip
+import traceback
 from js import document, location
 from collections.abc import Sequence
 from collections import namedtuple
@@ -149,6 +150,7 @@ def execute(cmd):
                     console += '\\n{}'.format(text)
                 s.flush()
         except Exception:
+            console += '{}\\n{}'.format(command, traceback.format_exc())
             # Failed for some reason, so quit
             break
 

--- a/docs/theme/playground.css
+++ b/docs/theme/playground.css
@@ -136,14 +136,10 @@ div.color-command .highlight:not(:first-child) {
 
 .playground-inputs {
   -webkit-appearance: textarea;
-  position: absolute;
   margin: 0;
-  top: 0;
-  left: 0;
   display: block;
   width: 100%;
   min-height: 3em;
-  height: calc(100% + 0.2rem);
   border: none;
   padding: .7720588235em 1.1764705882em;
   outline: none;
@@ -151,8 +147,8 @@ div.color-command .highlight:not(:first-child) {
   overflow-x: auto;
   overflow-y: hidden;
   caret-color: var(--md-code-fg-color);
-  color: transparent;
-  background-color: transparent;
+  color: var(--md-code-fg-color);
+  background: var(--md-code-bg-color);
   font-feature-settings: "kern";
   font-family: var(--md-code-font-family,_),SFMono-Regular,Consolas,Menlo,monospace;
   line-height: 1.4;
@@ -220,6 +216,10 @@ div.color-command .highlight:not(:first-child) {
 .hidden .highlight,
 .hidden .playground-inputs,
 button.hidden {
+  display: none;
+}
+
+.playground-code:not(.hidden) div.highlight {
   display: none;
 }
 


### PR DESCRIPTION
Playground code blocks improve performance and usability.

- Do not syntax highlight code while editing. While cool, and useful,
  it is slow on mobile devices and very under-powered devices,
  especially when dealing with large code size. Don't syntax highlight
  so that that editing loads faster and is not bogged down with Pygments
  processing which is not designed to be used for live editing.
- Show traces when a command fails. This is useful to the user so they
  know they did something wrong, and what.

Overall, the experience should be better, even if we lose live syntax
highlighting.