### PR TITLE
Ensure that we are more strictly following CSS format for commas

### DIFF
--- a/coloraide/spaces/hwb/css.py
+++ b/coloraide/spaces/hwb/css.py
@@ -13,15 +13,12 @@ if TYPE_CHECKING:  # pragma: no cover
 class HWB(base.HWB):
     """HWB class."""
 
-    DEF_VALUE = "hwb(0 0% 0% / 1)"
     MATCH = re.compile(
         r"""(?xi)
         \bhwb\(\s*
         (?:
             # Space separated format
-            {angle}{space}{percent}{space}{percent}(?:{slash}(?:{percent}|{float}))? |
-            # comma separated format
-            {angle}{comma}{percent}{comma}{percent}(?:{comma}(?:{percent}|{float}))?
+            {angle}{space}{percent}{space}{percent}(?:{slash}(?:{percent}|{float}))?
         )
         \s*\)
         """.format(**parse.COLOR_PARTS)
@@ -54,7 +51,7 @@ class HWB(base.HWB):
             coords = util.no_nans(coords)
 
         if alpha:
-            template = "hwb({}, {}, {}, {})" if options.get("comma") else "hwb({} {} {} / {})"
+            template = "hwb({} {} {} / {})"
             return template.format(
                 util.fmt_float(coords[0], precision),
                 util.fmt_percent(coords[1] * 100, precision),
@@ -62,7 +59,7 @@ class HWB(base.HWB):
                 util.fmt_float(self.alpha, max(util.DEF_PREC, precision))
             )
         else:
-            template = "hwb({}, {}, {})" if options.get("comma") else "hwb({} {} {})"
+            template = "hwb({} {} {})"
             return template.format(
                 util.fmt_float(coords[0], precision),
                 util.fmt_percent(coords[1] * 100, precision),

--- a/coloraide/spaces/lab/css.py
+++ b/coloraide/spaces/lab/css.py
@@ -19,9 +19,7 @@ class Lab(base.Lab):
             \blab\(\s*
             (?:
                 # Space separated format
-                {percent}{space}{float}{space}{float}(?:{slash}(?:{percent}|{float}))? |
-                # comma separated format
-                {percent}{comma}{float}{comma}{float}(?:{comma}(?:{percent}|{float}))?
+                {percent}{space}{float}{space}{float}(?:{slash}(?:{percent}|{float}))?
             )
             \s*\)
         )
@@ -55,7 +53,7 @@ class Lab(base.Lab):
             coords = util.no_nans(coords)
 
         if alpha:
-            template = "lab({}, {}, {}, {})" if options.get("comma") else "lab({} {} {} / {})"
+            template = "lab({} {} {} / {})"
             return template.format(
                 util.fmt_percent(coords[0], precision),
                 util.fmt_float(coords[1], precision),
@@ -63,7 +61,7 @@ class Lab(base.Lab):
                 util.fmt_float(a, max(util.DEF_PREC, precision))
             )
         else:
-            template = "lab({}, {}, {})" if options.get("comma") else "lab({} {} {})"
+            template = "lab({} {} {})"
             return template.format(
                 util.fmt_percent(coords[0], precision),
                 util.fmt_float(coords[1], precision),

--- a/coloraide/spaces/lch/css.py
+++ b/coloraide/spaces/lch/css.py
@@ -18,9 +18,7 @@ class Lch(base.Lch):
         \blch\(\s*
         (?:
             # Space separated format
-            {percent}{space}{float}{space}{angle}(?:{slash}(?:{percent}|{float}))? |
-            # comma separated format
-            {percent}{comma}{float}{comma}{angle}(?:{comma}(?:{percent}|{float}))?
+            {percent}{space}{float}{space}{angle}(?:{slash}(?:{percent}|{float}))?
         )
         \s*\)
         """.format(**parse.COLOR_PARTS)
@@ -53,7 +51,7 @@ class Lch(base.Lch):
             coords = util.no_nans(coords)
 
         if alpha:
-            template = "lch({}, {}, {}, {})" if options.get("comma") else "lch({} {} {} / {})"
+            template = "lch({} {} {} / {})"
             return template.format(
                 util.fmt_percent(coords[0], precision),
                 util.fmt_float(coords[1], precision),
@@ -61,7 +59,7 @@ class Lch(base.Lch):
                 util.fmt_float(a, max(util.DEF_PREC, precision))
             )
         else:
-            template = "lch({}, {}, {})" if options.get("comma") else "lch({} {} {})"
+            template = "lch({} {} {})"
             return template.format(
                 util.fmt_percent(coords[0], precision),
                 util.fmt_float(coords[1], precision),

--- a/coloraide/spaces/oklab/css.py
+++ b/coloraide/spaces/oklab/css.py
@@ -19,9 +19,7 @@ class Oklab(base.Oklab):
             \bOklab\(\s*
             (?:
                 # Space separated format
-                {percent}{space}{float}{space}{float}(?:{slash}(?:{percent}|{float}))? |
-                # comma separated format
-                {percent}{comma}{float}{comma}{float}(?:{comma}(?:{percent}|{float}))?
+                {percent}{space}{float}{space}{float}(?:{slash}(?:{percent}|{float}))?
             )
             \s*\)
         )
@@ -55,7 +53,7 @@ class Oklab(base.Oklab):
             coords = util.no_nans(coords)
 
         if alpha:
-            template = "oklab({}, {}, {}, {})" if options.get("comma") else "oklab({} {} {} / {})"
+            template = "oklab({} {} {} / {})"
             return template.format(
                 util.fmt_percent(coords[0] * 100, precision),
                 util.fmt_float(coords[1], precision),
@@ -63,7 +61,7 @@ class Oklab(base.Oklab):
                 util.fmt_float(a, max(util.DEF_PREC, precision))
             )
         else:
-            template = "oklab({}, {}, {})" if options.get("comma") else "oklab({} {} {})"
+            template = "oklab({} {} {})"
             return template.format(
                 util.fmt_percent(coords[0] * 100, precision),
                 util.fmt_float(coords[1], precision),

--- a/coloraide/spaces/oklch/css.py
+++ b/coloraide/spaces/oklch/css.py
@@ -18,9 +18,7 @@ class Oklch(base.Oklch):
         \boklch\(\s*
         (?:
             # Space separated format
-            {percent}{space}{float}{space}{angle}(?:{slash}(?:{percent}|{float}))? |
-            # comma separated format
-            {percent}{comma}{float}{comma}{angle}(?:{comma}(?:{percent}|{float}))?
+            {percent}{space}{float}{space}{angle}(?:{slash}(?:{percent}|{float}))?
         )
         \s*\)
         """.format(**parse.COLOR_PARTS)
@@ -53,7 +51,7 @@ class Oklch(base.Oklch):
             coords = util.no_nans(coords)
 
         if alpha:
-            template = "oklch({}, {}, {}, {})" if options.get("comma") else "oklch({} {} {} / {})"
+            template = "oklch({} {} {} / {})"
             return template.format(
                 util.fmt_percent(coords[0] * 100, precision),
                 util.fmt_float(coords[1], precision),
@@ -61,7 +59,7 @@ class Oklch(base.Oklch):
                 util.fmt_float(a, max(util.DEF_PREC, precision))
             )
         else:
-            template = "oklch({}, {}, {})" if options.get("comma") else "oklch({} {} {})"
+            template = "oklch({} {} {})"
             return template.format(
                 util.fmt_percent(coords[0] * 100, precision),
                 util.fmt_float(coords[1], precision),

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -4,6 +4,8 @@
 
 - **NEW**: Refactor chroma reduction/MINDE logic to cut processing time in half. Gamut mapping results remain very
   similar.
+- **NEW**: Be more strict with CSS inputs and outputs. `hwb()`, `lab()`, `lch()`, `oklab()`, and `oklch()` no longer
+  support comma string formats.
 
 ## 0.10.0
 

--- a/docs/src/markdown/strings.md
+++ b/docs/src/markdown/strings.md
@@ -103,11 +103,8 @@ These options may occur in various color spaces depending on the CSS output form
 
 ### Comma
 
-In CSS, there are a number of color spaces that allow a comma format: `srgb` and `hsl`. ColorAide allows these to be
-read in and to be output in their legacy comma format. Even though `lch`, `lab`, `oklab`, `oklch`, and `hwb` do not have
-a comma format, they are allowed to be read in with commas and can be specified to output with comma format. The one
-format that ColorAide will not allow commas on is `color()`. `color()` is the common serialization format that ColorAide
-uses and it is strict about its format.
+In CSS, there are a few color spaces that allow a comma format: `srgb` and `hsl`. ColorAide allows these to be read in
+and to be output in their legacy comma format. These are the only formats that ship with comma support.
 
 If we want commas, we can force the comma syntax by setting `comma` to `#!py3 True`. This can alter some color space
 output in other subtle ways. As the comma format is the old legacy approach, when sRGB has commas enabled, it will use

--- a/tests/test_hwb.py
+++ b/tests/test_hwb.py
@@ -32,23 +32,6 @@ class TestHWBInputOutput(util.ColorAsserts, unittest.TestCase):
         color = "color(--hwb 20 10% 75% / 50%)"
         self.assertEqual(Color(color).to_string(**args), 'color(--hwb 20 0.1 0.75 / 0.5)')
 
-    def test_comma(self):
-        """Test comma input and comma output format."""
-
-        args = {"comma": True}
-
-        color = "hwb(20, 10%, 75%)"
-        hwb = Color(color)
-        self.assertEqual(color, hwb.to_string(**args))
-
-        color = "hwb(20, 10%, 75%, 1)"
-        hwb = Color(color)
-        self.assertEqual("hwb(20, 10%, 75%)", hwb.to_string(**args))
-
-        color = "hwb(20, 10%, 75%, 0.2)"
-        hwb = Color(color)
-        self.assertEqual("hwb(20, 10%, 75%, 0.2)", hwb.to_string(**args))
-
     def test_space(self):
         """Test space input and space output format."""
 
@@ -69,17 +52,7 @@ class TestHWBInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_percent(self):
         """Test that percents work properly."""
 
-        args = {"comma": True}
-
-        color = "hwb(20, 10%, 75%, 100%)"
-        hwb = Color(color)
-        self.assertEqual("hwb(20, 10%, 75%)", hwb.to_string(**args))
-
-        color = "hwb(20, 10%, 75%, 20%)"
-        hwb = Color(color)
-        self.assertEqual("hwb(20, 10%, 75%, 0.2)", hwb.to_string(**args))
-
-        args["comma"] = False
+        args = {}
 
         color = "hwb(20 10% 75% / 100%)"
         hwb = Color(color)
@@ -92,13 +65,7 @@ class TestHWBInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_no_alpha(self):
         """Test no alpha."""
 
-        args = {"comma": True, "alpha": False}
-
-        color = "hwb(20, 10%, 75%, 0.2)"
-        hwb = Color(color)
-        self.assertEqual("hwb(20, 10%, 75%)", hwb.to_string(**args))
-
-        args["comma"] = False
+        args = {"alpha": False}
 
         color = "hwb(20 10% 75% / 0.2)"
         hwb = Color(color)
@@ -107,13 +74,7 @@ class TestHWBInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_force_alpha(self):
         """Test force alpha."""
 
-        args = {"comma": True, "alpha": True}
-
-        color = "hwb(20, 10%, 75%, 1)"
-        hwb = Color(color)
-        self.assertEqual("hwb(20, 10%, 75%, 1)", hwb.to_string(**args))
-
-        args["comma"] = False
+        args = {"alpha": True}
 
         color = "hwb(20 10% 75% / 1)"
         hwb = Color(color)
@@ -152,19 +113,19 @@ class TestHWBInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_hue_inputs(self):
         """Test hue inputs."""
 
-        color = "hwb(90deg, 50%, 20%)"
+        color = "hwb(90deg 50% 20%)"
         hwb = Color(color)
         self.assertEqual("hwb(90 50% 20%)", hwb.to_string())
 
-        color = "hwb({:f}rad, 50%, 20%)".format(math.radians(90))
+        color = "hwb({:f}rad 50% 20%)".format(math.radians(90))
         hwb = Color(color)
         self.assertEqual("hwb(90 50% 20%)", hwb.to_string())
 
-        color = "hwb(100grad, 50%, 20%)"
+        color = "hwb(100grad 50% 20%)"
         hwb = Color(color)
         self.assertEqual("hwb(90 50% 20%)", hwb.to_string())
 
-        color = "hwb(0.25turn, 50%, 20%)"
+        color = "hwb(0.25turn 50% 20%)"
         hwb = Color(color)
         self.assertEqual("hwb(90 50% 20%)", hwb.to_string())
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -31,23 +31,6 @@ class TestLabInputOutput(util.ColorAsserts, unittest.TestCase):
         color = "color(--lab 20% 10 -30 / 50%)"
         self.assertEqual(Color(color).to_string(**args), 'color(--lab 20 10 -30 / 0.5)')
 
-    def test_comma(self):
-        """Test comma input and comma output format."""
-
-        args = {"comma": True}
-
-        color = "lab(20%, 10, -30)"
-        lab = Color(color)
-        self.assertEqual(color, lab.to_string(**args))
-
-        color = "lab(20%, 10, -30, 1)"
-        lab = Color(color)
-        self.assertEqual("lab(20%, 10, -30)", lab.to_string(**args))
-
-        color = "lab(20%, 10, -30, 0.2)"
-        lab = Color(color)
-        self.assertEqual("lab(20%, 10, -30, 0.2)", lab.to_string(**args))
-
     def test_space(self):
         """Test space input and space output format."""
 
@@ -68,17 +51,7 @@ class TestLabInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_percent(self):
         """Test that percents work properly."""
 
-        args = {"comma": True}
-
-        color = "lab(20%, 10, -30, 100%)"
-        lab = Color(color)
-        self.assertEqual("lab(20%, 10, -30)", lab.to_string(**args))
-
-        color = "lab(20%, 10, -30, 20%)"
-        lab = Color(color)
-        self.assertEqual("lab(20%, 10, -30, 0.2)", lab.to_string(**args))
-
-        args["comma"] = False
+        args = {}
 
         color = "lab(20% 10 -30 / 100%)"
         lab = Color(color)
@@ -91,13 +64,7 @@ class TestLabInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_no_alpha(self):
         """Test no alpha."""
 
-        args = {"comma": True, "alpha": False}
-
-        color = "lab(20%, 10, -30, 0.2)"
-        lab = Color(color)
-        self.assertEqual("lab(20%, 10, -30)", lab.to_string(**args))
-
-        args["comma"] = False
+        args = {"alpha": False}
 
         color = "lab(20% 10 -30 / 0.2)"
         lab = Color(color)
@@ -106,13 +73,7 @@ class TestLabInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_force_alpha(self):
         """Test force alpha."""
 
-        args = {"comma": True, "alpha": True}
-
-        color = "lab(20%, 10, -30, 1)"
-        lab = Color(color)
-        self.assertEqual("lab(20%, 10, -30, 1)", lab.to_string(**args))
-
-        args["comma"] = False
+        args = {"alpha": True}
 
         color = "lab(20% 10 -30 / 1)"
         lab = Color(color)

--- a/tests/test_lch.py
+++ b/tests/test_lch.py
@@ -32,23 +32,6 @@ class TestLCHInputOutput(util.ColorAsserts, unittest.TestCase):
         color = "color(--lch 20% 10 130 / 50%)"
         self.assertEqual(Color(color).to_string(**args), 'color(--lch 20 10 130 / 0.5)')
 
-    def test_comma(self):
-        """Test comma input and comma output format."""
-
-        args = {"comma": True}
-
-        color = "lch(20%, 10, 130)"
-        lch = Color(color)
-        self.assertEqual(color, lch.to_string(**args))
-
-        color = "lch(20%, 10, 130, 1)"
-        lch = Color(color)
-        self.assertEqual("lch(20%, 10, 130)", lch.to_string(**args))
-
-        color = "lch(20%, 10, 130, 0.2)"
-        lch = Color(color)
-        self.assertEqual("lch(20%, 10, 130, 0.2)", lch.to_string(**args))
-
     def test_space(self):
         """Test space input and space output format."""
 
@@ -69,17 +52,7 @@ class TestLCHInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_percent(self):
         """Test that percents work properly."""
 
-        args = {"comma": True}
-
-        color = "lch(20%, 10, 130, 100%)"
-        lch = Color(color)
-        self.assertEqual("lch(20%, 10, 130)", lch.to_string(**args))
-
-        color = "lch(20%, 10, 130, 20%)"
-        lch = Color(color)
-        self.assertEqual("lch(20%, 10, 130, 0.2)", lch.to_string(**args))
-
-        args["comma"] = False
+        args = {}
 
         color = "lch(20% 10 130 / 100%)"
         lch = Color(color)
@@ -92,13 +65,7 @@ class TestLCHInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_no_alpha(self):
         """Test no alpha."""
 
-        args = {"comma": True, "alpha": False}
-
-        color = "lch(20%, 10, 130, 0.2)"
-        lch = Color(color)
-        self.assertEqual("lch(20%, 10, 130)", lch.to_string(**args))
-
-        args["comma"] = False
+        args = {"alpha": False}
 
         color = "lch(20% 10 130 / 0.2)"
         lch = Color(color)
@@ -107,13 +74,7 @@ class TestLCHInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_force_alpha(self):
         """Test force alpha."""
 
-        args = {"comma": True, "alpha": True}
-
-        color = "lch(20%, 10, 130, 1)"
-        lch = Color(color)
-        self.assertEqual("lch(20%, 10, 130, 1)", lch.to_string(**args))
-
-        args["comma"] = False
+        args = {"alpha": True}
 
         color = "lch(20% 10 130 / 1)"
         lch = Color(color)
@@ -152,19 +113,19 @@ class TestLCHInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_hue_inputs(self):
         """Test hue inputs."""
 
-        color = "lch(90%, 50, 90deg)"
+        color = "lch(90% 50 90deg)"
         lch = Color(color)
         self.assertEqual("lch(90% 50 90)", lch.to_string())
 
-        color = "lch(90%, 50, {:f}rad)".format(math.radians(90))
+        color = "lch(90% 50 {:f}rad)".format(math.radians(90))
         lch = Color(color)
         self.assertEqual("lch(90% 50 90)", lch.to_string())
 
-        color = "lch(90%, 50, 100grad)"
+        color = "lch(90% 50 100grad)"
         lch = Color(color)
         self.assertEqual("lch(90% 50 90)", lch.to_string())
 
-        color = "lch(90%, 50, 0.25turn)"
+        color = "lch(90% 50 0.25turn)"
         lch = Color(color)
         self.assertEqual("lch(90% 50 90)", lch.to_string())
 

--- a/tests/test_oklab.py
+++ b/tests/test_oklab.py
@@ -31,23 +31,6 @@ class TestOklabInputOutput(util.ColorAsserts, unittest.TestCase):
         color = "color(--oklab 100% 0.2 -0.3 / 50%)"
         self.assertEqual(Color(color).to_string(**args), 'color(--oklab 1 0.2 -0.3 / 0.5)')
 
-    def test_comma(self):
-        """Test comma input and comma output format."""
-
-        args = {"comma": True}
-
-        color = "oklab(20%, 0.1, -0.3)"
-        lab = Color(color)
-        self.assertEqual(color, lab.to_string(**args))
-
-        color = "oklab(20%, 0.1, -0.3, 1)"
-        lab = Color(color)
-        self.assertEqual("oklab(20%, 0.1, -0.3)", lab.to_string(**args))
-
-        color = "oklab(20%, 0.1, -0.30, 0.2)"
-        lab = Color(color)
-        self.assertEqual("oklab(20%, 0.1, -0.3, 0.2)", lab.to_string(**args))
-
     def test_space(self):
         """Test space input and space output format."""
 
@@ -68,17 +51,7 @@ class TestOklabInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_percent(self):
         """Test that percents work properly."""
 
-        args = {"comma": True}
-
-        color = "oklab(20%, 0.1, -0.3, 100%)"
-        lab = Color(color)
-        self.assertEqual("oklab(20%, 0.1, -0.3)", lab.to_string(**args))
-
-        color = "oklab(20%, 0.1, -0.3, 20%)"
-        lab = Color(color)
-        self.assertEqual("oklab(20%, 0.1, -0.3, 0.2)", lab.to_string(**args))
-
-        args["comma"] = False
+        args = {}
 
         color = "oklab(20% 0.1 -0.3 / 100%)"
         lab = Color(color)
@@ -91,12 +64,6 @@ class TestOklabInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_no_alpha(self):
         """Test no alpha."""
 
-        args = {"comma": True, "alpha": False}
-
-        color = "oklab(100%, 0.2, -0.3, 0.5)"
-        oklab = Color(color)
-        self.assertEqual("oklab(100%, 0.2, -0.3)", oklab.to_string(**args))
-
         args = {"alpha": False}
 
         color = "oklab(100% 0.2 -0.3 / 0.5)"
@@ -105,12 +72,6 @@ class TestOklabInputOutput(util.ColorAsserts, unittest.TestCase):
 
     def test_force_alpha(self):
         """Test force alpha."""
-
-        args = {"comma": True, "alpha": True}
-
-        color = "oklab(100%, 0.2, -0.3, 100%)"
-        oklab = Color(color)
-        self.assertEqual("oklab(100%, 0.2, -0.3, 1)", oklab.to_string(**args))
 
         args = {"alpha": True}
 

--- a/tests/test_oklch.py
+++ b/tests/test_oklch.py
@@ -40,23 +40,6 @@ class TestOklchInputOutput(util.ColorAsserts, unittest.TestCase):
         color = "color(--oklch 90% 0.5 270 / 50%)"
         self.assertEqual(Color(color).to_string(**args), 'color(--oklch 0.9 0.5 270 / 0.5)')
 
-    def test_comma(self):
-        """Test comma input and comma output format."""
-
-        args = {"comma": True}
-
-        color = "oklch(20%, 0.1, 130)"
-        lch = Color(color)
-        self.assertEqual(color, lch.to_string(**args))
-
-        color = "oklch(20%, 0.1, 130, 1)"
-        lch = Color(color)
-        self.assertEqual("oklch(20%, 0.1, 130)", lch.to_string(**args))
-
-        color = "oklch(20%, 0.1, 130, 0.2)"
-        lch = Color(color)
-        self.assertEqual("oklch(20%, 0.1, 130, 0.2)", lch.to_string(**args))
-
     def test_space(self):
         """Test space input and space output format."""
 
@@ -77,17 +60,7 @@ class TestOklchInputOutput(util.ColorAsserts, unittest.TestCase):
     def test_percent(self):
         """Test that percents work properly."""
 
-        args = {"comma": True}
-
-        color = "oklch(20%, 0.1, 130, 100%)"
-        lch = Color(color)
-        self.assertEqual("oklch(20%, 0.1, 130)", lch.to_string(**args))
-
-        color = "oklch(20%, 0.1, 130, 20%)"
-        lch = Color(color)
-        self.assertEqual("oklch(20%, 0.1, 130, 0.2)", lch.to_string(**args))
-
-        args["comma"] = False
+        args = {}
 
         color = "oklch(20% 0.1 130 / 100%)"
         lch = Color(color)


### PR DESCRIPTION
HWB, Lch, Lab, Oklch, and Oklab will no longer allow commas in their
format. They are not officially part of the CSS spec.

It is clear now that CSS will not allow commas in the new formats. The idea surfaced and was rejected. If we are claiming to parse CSS formats, we should parse them as they are specified.