### PR TITLE
Ensure `longer` evaluates longer when ∆θ = 0

### DIFF
--- a/coloraide/interpolate.py
+++ b/coloraide/interpolate.py
@@ -319,7 +319,7 @@ def adjust_hues(color1: 'Color', color2: 'Color', hue: str) -> None:
     elif hue == "longer":
         if 0 < (c2 - c1) < 180:
             c1 += 360
-        elif -180 < (c2 - c1) < 0:
+        elif -180 < (c2 - c1) <= 0:
             c2 += 360
 
     elif hue == "increasing":

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -5,13 +5,15 @@
 - **NEW**: Add new `closest` method that takes a list of colors and returns the one that is closet to the calling color
   object.
 - **NEW**: CSS color syntax no longer allows for forgiving channels in `color()`. This means that when a channel other
-  than alpha is omitted, that we will no longer treat them as undefined. Instead, the color will simply fail to parse.
+  than alpha is omitted, we will no longer treat them as undefined. Instead, the color will simply fail to parse.
   Raw data channels also must specify all channels.
 - **NEW**: Clamp lower bounds of chroma at the channel level.
 - **NEW**: `coloraide.spaces.WHITES` is now a 2 deep dictionary containing both 2˚ and 10˚ observer variants of white
   points.
 - **NEW**: Color space plugins now specify `WHITE` as a tuple with the x and y chromaticity coordinates. This allows a
   space to specify unknown white points if desired.
+- **FIX**: Fix `longer` hue interpolation when `θ1 - θ2 = 0`. The spec is wrong in this case, and interpolation should
+  still occur the long way around instead of keeping hue constant.
 - **FIX**: Reduce redundancy in some CSS parsing patterns.
 - **FIX**: Minor performance improvements.
 - **FIX**: Legacy `rgb()`, `rgba()`, `hsl()`, and `hsla()` comma separated forms in CSS do not support `none`, only the


### PR DESCRIPTION
Fixes #139 