### PR TITLE
Cache the conversion chain to speed up conversions more

### DIFF
--- a/coloraide/cvd.py
+++ b/coloraide/cvd.py
@@ -338,9 +338,11 @@ def cvd(color: 'Color', deficiency: str, severity: float = 1.0, method: Optional
 
     space = color.space()
     try:
-        get_algorithm(deficiency, method, severity >= 1.0)(color.convert('srgb-linear', in_place=True), severity)
+        algorithm = get_algorithm(deficiency, method, severity >= 1.0)
     except KeyError:
         raise ValueError(
             "Could not find a matching algorithm for deficiency '{}' and method '{}'".format(deficiency, method)
         )
+
+    algorithm(color.convert('srgb-linear', in_place=True), severity)
     return color.convert(space, in_place=True)


### PR DESCRIPTION
Once the optimal conversion chain is calculated for a color class,
cache it to speed up future conversions between the two color spaces.
When registering or deregistering color space plugins, clear the cache.
If subclassing, ensure the new class does not use the parent class's
cache.