### PR TITLE
Slight refactor to base interpolate plugin in regards to extrapolation

### DIFF
--- a/coloraide/__meta__.py
+++ b/coloraide/__meta__.py
@@ -192,5 +192,5 @@ def parse_version(ver: str) -> Version:
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 0, 0, "final")
+__version_info__ = Version(1, 1, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/coloraide/color.py
+++ b/coloraide/color.py
@@ -736,6 +736,7 @@ class Color(metaclass=ColorMeta):
         progress: Optional[Union[Mapping[str, Callable[..., float]], Callable[..., float]]] = None,
         hue: str = util.DEF_HUE_ADJ,
         premultiplied: bool = True,
+        extrapolate: bool = False,
         method: str = "linear",
         **kwargs: Any
     ) -> Interpolator:
@@ -760,6 +761,7 @@ class Color(metaclass=ColorMeta):
             progress=progress,
             hue=hue,
             premultiplied=premultiplied,
+            extrapolate=extrapolate,
             **kwargs
         )
 

--- a/coloraide/interpolate/__init__.py
+++ b/coloraide/interpolate/__init__.py
@@ -82,7 +82,7 @@ class Interpolator(metaclass=ABCMeta):
         self.space = space
         self.out_space = out_space
         self.extrapolate = extrapolate
-        self.current_easing = None
+        self.current_easing = None  # type: Optional[Union[Callable[..., float], Mapping[str, Callable[..., float]]]]
         cs = self.create.CS_MAP[out_space]
         if isinstance(cs, Cylindrical):
             self.hue_index = cast(Cylindrical, cs).hue_index()
@@ -219,7 +219,7 @@ class Interpolator(metaclass=ABCMeta):
         adjusted_time = (point - last) / r if r else 1
 
         # Do we have an easing function between these stops?
-        self.current_easing = self.easings[index - 1]  # type: Any
+        self.current_easing = self.easings[index - 1]
         if self.current_easing is None:
             self.current_easing = self.progress
 

--- a/coloraide/interpolate/bspline.py
+++ b/coloraide/interpolate/bspline.py
@@ -162,6 +162,10 @@ class InterpolatorBSpline(Interpolator):
 
             channels.append(self.calculate(p0, p1, p2, p3, t))
 
+        # Small adjustment for floating point math and alpha channels
+        if 1 - channels[-1] < 1e-6:
+            channels[-1] = 1
+
         return channels
 
 

--- a/coloraide/interpolate/linear.py
+++ b/coloraide/interpolate/linear.py
@@ -54,7 +54,6 @@ class InterpolatorLinear(Interpolator):
 
     def interpolate(
         self,
-        easing: Optional[Union[Callable[..., float], Mapping[str, Callable[..., float]]]],
         point: float,
         index: int
     ) -> Vector:
@@ -79,21 +78,8 @@ class InterpolatorLinear(Interpolator):
 
             # Using linear interpolation between the two points
             else:
-                # Do we have an easing function, or mapping with a channel easing function?
-                progress = None
-                name = self.channel_names[i]
-                if isinstance(easing, Mapping):
-                    progress = easing.get(name)
-                    if progress is None:
-                        progress = easing.get('all')
-                else:
-                    progress = easing
-
-                # Apply easing and scale properly between the colors
-                t = alg.clamp(point if progress is None else progress(point), 0.0, 1.0)
-
                 # Interpolate
-                value = alg.lerp(a, b, t)
+                value = alg.lerp(a, b, self.ease(point, i))
             channels.append(value)
 
         return channels
@@ -115,6 +101,7 @@ class Linear(Interpolate):
         out_space: str,
         progress: Optional[Union[Mapping[str, Callable[..., float]], Callable[..., float]]],
         premultiplied: bool,
+        extrapolate: bool = False,
         **kwargs: Any
     ) -> Interpolator:
         """Return the linear interpolator."""
@@ -128,5 +115,6 @@ class Linear(Interpolate):
             space,
             out_space,
             progress,
-            premultiplied
+            premultiplied,
+            extrapolate
         )

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -32,6 +32,7 @@ CMYK
 CSS
 CVD
 CVDs
+Catmull
 Changelog
 Chroma
 Chromaticities

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0
+
+- **NEW**: Interpolator plugins now send the requested `point` along the interpolation line un-clamped so that an
+  interpolation plugin could potentially allow values beyond the domain of 0 - 1. No default plugin extrapolates, or
+  provides periodic interpolation, but we do not want to make it difficult to do so in the future.
+
 ## 1.0
 
 !!! success "Stable Release!"

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,8 +3,12 @@
 ## 1.1.0
 
 - **NEW**: Interpolator plugins now send the requested `point` along the interpolation line un-clamped so that an
-  interpolation plugin could potentially allow values beyond the domain of 0 - 1. No default plugin extrapolates, or
-  provides periodic interpolation, but we do not want to make it difficult to do so in the future.
+  interpolation plugin can conditionally allow values to be extrapolated beyond the domain of 0 - 1.
+- **NEW**: Slight refactor of interpolation plugin so that common code does not need to be duplicated, and the
+  `interpolate` method no longer needs to accept an `easing` parameter as the plugin class exposes a new `ease` method
+  to automatically acquire the proper, specified easing function and apply it.
+- **NEW**: Functions built upon interpolation can now use a new `extrapolate` parameter to enable extrapolation if
+  interpolation inputs exceed 0 - 1.
 
 ## 1.0
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -9,6 +9,8 @@
   to automatically acquire the proper, specified easing function and apply it.
 - **NEW**: Functions built upon interpolation can now use a new `extrapolate` parameter to enable extrapolation if
   interpolation inputs exceed 0 - 1.
+- **FIX**: Due to floating point math, B-spline will sometimes return an interpolation of fully opaque colors with an
+  imperceptible amount of transparency. If alpha is very close (`#!py3 1e-6`) to being opaque, just round it to opaque.
 
 ## 1.0
 

--- a/docs/src/markdown/api/index.md
+++ b/docs/src/markdown/api/index.md
@@ -691,6 +691,7 @@ def interpolate(
     out_space=None,
     hue=util.DEF_HUE_ADJ,
     premultiplied=True,
+    extrapolate=False,
     method='linear'
 ):
 ```
@@ -734,6 +735,7 @@ Parameters
     `out_space`     | `#!py3 None`      | Color space that the new color should be in. If `#!py3 None`, the color will be in the same color space as the base color.
     `hue`           | `#!py3 "shorter"` | Define how color spaces which have hue angles are interpolated. Default evaluates between the shortest angle.
     `premultiplied` | `#!py3 True`      | Use premultiplied alpha when interpolating.
+    `extrapolate`   | `#!py3 False`     | Interpolations should extrapolate when values exceed the 0 - 1 range.
     `method`        | `#!py3 "linear"`  | The interpolation method to use.
 
 Return

--- a/docs/src/mkdocs.yml
+++ b/docs/src/mkdocs.yml
@@ -205,7 +205,7 @@ extra_css:
   - assets/coloraide-extras/extra.css
 extra_javascript:
   - https://unpkg.com/mermaid@8.13.3/dist/mermaid.min.js
-  - playground-config-3c7321de.js
+  - playground-config-1e20e984.js
   - https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js
   - assets/coloraide-extras/extra-notebook.js
 

--- a/docs/theme/playground-config-1e20e984.js
+++ b/docs/theme/playground-config-1e20e984.js
@@ -1,0 +1,5 @@
+var color_notebook = {
+    "playground_wheels": ['Pygments-2.12.0-py3-none-any.whl', 'coloraide-1.1-py3-none-any.whl'],
+    "notebook_wheels": ['Markdown-3.3.4-py3-none-any.whl', 'pymdown_extensions-9.5-py3-none-any.whl', 'Pygments-2.12.0-py3-none-any.whl', 'coloraide-1.1-py3-none-any.whl'],
+    "default_playground": "import coloraide\ncoloraide.__version__\nColor('red')"
+}

--- a/docs/theme/playground-config-3c7321de.js
+++ b/docs/theme/playground-config-3c7321de.js
@@ -1,5 +1,0 @@
-var color_notebook = {
-    "playground_wheels": ['Pygments-2.12.0-py3-none-any.whl', 'coloraide-1.0-py3-none-any.whl'],
-    "notebook_wheels": ['Markdown-3.3.4-py3-none-any.whl', 'pymdown_extensions-9.5-py3-none-any.whl', 'Pygments-2.12.0-py3-none-any.whl', 'coloraide-1.0-py3-none-any.whl'],
-    "default_playground": "import coloraide\ncoloraide.__version__\nColor('red')"
-}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,7 +205,7 @@ extra_css:
   - assets/coloraide-extras/extra-753860a807.css
 extra_javascript:
   - https://unpkg.com/mermaid@8.13.3/dist/mermaid.min.js
-  - playground-config-3c7321de.js
+  - playground-config-1e20e984.js
   - https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js
   - assets/coloraide-extras/extra-notebook-6edfcb69.js
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -1007,3 +1007,34 @@ class TestInterpolation(util.ColorAsserts, unittest.TestCase):
             )(0.75),
             Color('rgb(8.5 140.25 106.25 / 0.625)')
         )
+
+    def test_extrapolate_bspline(self):
+        """
+        Test that extrapolation of B-spline is linear after the first and last control point.
+
+        Values have been vetted by plotting a complete curve that extrapolates past the endpoints.
+        """
+
+        i = Color.interpolate(
+            ["oklab(0.7 0.15 0.1)", "oklab(0.7 -0.05 0.1)", "oklab(0.7 -0.09 0.02)", "oklab(0.7 -0.03 -0.12)"],
+            method='bspline',
+            extrapolate=True
+        )
+        self.assertColorEqual(i(-0.5), Color('oklab(0.7 0.2625 0.1)'))
+        print(i(1.5)[:], Color('oklab(0.7 0.00375 -0.19875 / 1)')[:])
+        self.assertColorEqual(i(1.5), Color('oklab(0.7 0.00375 -0.19875 / 1)'))
+
+    def test_extrapolate_linear(self):
+        """
+        Test that extrapolation of linear makes sense.
+
+        Values have been vetted by plotting a complete curve that extrapolates past the endpoints.
+        """
+
+        i = Color.interpolate(
+            ["oklab(0.7 0.15 0.1)", "oklab(0.7 -0.05 0.1)", "oklab(0.7 -0.09 0.02)", "oklab(0.7 -0.03 -0.12)"],
+            method='linear',
+            extrapolate=True
+        )
+        self.assertColorEqual(i(-0.5), Color('oklab(0.7 0.45 0.1)'))
+        self.assertColorEqual(i(1.5), Color('oklab(0.7 0.06 -0.33)'))

--- a/tools/interp_diagram.py
+++ b/tools/interp_diagram.py
@@ -51,6 +51,7 @@ def main():
     parser.add_argument('--position', '-p', default=0.5, type=float, help="Position between to show interpolated.")
     parser.add_argument('--gamut', '-g', default="srgb", help='Gamut to evaluate the color in (default is sRGB).')
     parser.add_argument('--method', '-m', default='linear', help="Interplation method to use: linear, bezier, etc.")
+    parser.add_argument('--extrapolate', '-e', action='store_true', help='Extrapolate values.')
     parser.add_argument('--title', '-T', default='', help="Provide a title for the diagram.")
     parser.add_argument('--subtitle', '-t', default='', help="Provide a subtitle for the diagram.")
     parser.add_argument(
@@ -114,9 +115,15 @@ def main():
 
     xs = []
     ys = []
-    for item in Color.steps(colors, steps=100, space=args.space, method=args.method):
-        xs.append(item.get(name1) if hue_index == -1 else math.radians(item.get(name1)))
-        ys.append(item.get(name2))
+    i = Color.interpolate(colors, space=args.space, method=args.method, extrapolate=args.extrapolate)
+    if not args.extrapolate:
+        offset, factor = 0, 100
+    else:
+        offset, factor = 25, 50
+    for r in range(101):
+        c = i((r - offset) / factor)
+        xs.append(c.get(name1) if hue_index == -1 else math.radians(c.get(name1)))
+        ys.append(c.get(name2))
 
     xs, ys = get_spline(xs, ys, len(xs) * 3)
 


### PR DESCRIPTION
We do not currently do extrapolation in any of our interpolators, but
we shouldn't make it difficult to do so.

The desired point on the interpolation line should remain unmodified
through the call chain up until the a user would write custom
interpolation code, e.g. the `interpolate` function of the
`Interpolator` class.

Once there, they can decide if they'd like to not clamp the value. This
can be useful if a periodic, closed loop interpolator was desired. In
this case, it may be beneficial to allow values beyond 0 and 1, and wrap
them.

Resolves #230 
Resolves #229 