### PR TITLE
Even faster HCT conversion

### DIFF
--- a/coloraide/spaces/hct.py
+++ b/coloraide/spaces/hct.py
@@ -163,9 +163,14 @@ def hct_to_xyz(coords: Vector, env: Environment) -> Vector:
     y = lstar_to_y(t, env.ref_white)
 
     # Try to start with a reasonable initial guess for J
-    xyz = cam16_to_xyz_d65(J=t, C=c, h=h, env=env)
-    xyz[1] = y
-    j = xyz_d65_to_cam16(xyz, env)[0]
+    if c < 142:
+        # Calculated by curve fitting J vs T. Works well with colors within a mid-sized gamut, but not ultra wide.
+        j = 0.00462403 * t ** 2 + 0.51460278 * t + 2.62845677
+    else:
+        # For ultra wide gamuts we can get a better J by correcting Y in XYZ and then calculating our J
+        xyz = cam16_to_xyz_d65(J=t, C=c, h=h, env=env)
+        xyz[1] = y
+        j = xyz_d65_to_cam16(xyz, env)[0]
 
     # Try to find a J such that the returned y matches the returned y of the L*
     attempt = 0

--- a/tests/test_hct.py
+++ b/tests/test_hct.py
@@ -61,6 +61,17 @@ class TestHCTSerialize(util.ColorAssertsPyTest):
         self.assertEqual(Color(color1).to_string(**options), color2)
 
 
+class TestHCTMisc(util.ColorAsserts, unittest.TestCase):
+    """Test miscellaneous cases."""
+
+    def test_wide_gamut(self):
+        """Test wide gamut conversion logic."""
+
+        c1 = Color('hct', (330.2920013462662, 484.58580542051413, 91.57114928085913))
+        c2 = c1.convert('xyy').convert('hct')
+        self.assertColorEqual(c1, c2)
+
+
 class TestHCTPoperties(util.ColorAsserts, unittest.TestCase):
     """Test HCT properties."""
 


### PR DESCRIPTION
We curve fitted CAM16 J vs HCT T to come up with a polynomial to guess the best J possible for Newton Raphson. If the color has a very wide gamut, we will just correct the luminance in XYZ instead as the J vs T relationship changes as chroma gets larger causing the initial J guess to get worse in some regions as chroma increase.