### PR TITLE
Use ITS-90 C2 and C1 constant for CCT

### DIFF
--- a/coloraide/temperature/ohno_2013.py
+++ b/coloraide/temperature/ohno_2013.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:  # pragma: no cover
     from ..color import Color
 
-
 DEFAULT_WHITE = tuple(util.xy_to_xyz(cat.WHITES['2deg']['D65']))
 
 

--- a/coloraide/temperature/planck.py
+++ b/coloraide/temperature/planck.py
@@ -8,13 +8,18 @@ import math
 from ..types import VectorLike, Vector
 from .. import util
 
-
 # Constants for Planck's Law
-H = 6.62607015e-34 * 1e18  # Plank's constant: `nm2 kg / s`
-C = 299792458 * 1e9  # Speed of light: `nm / s`
-K = 1.380649e-23 * 1e18  # Boltzmann constant: `nm2 kg s-2 K-1`
-C1 = 2 * math.pi * H * C ** 2  # First radiation constant
-C2 = (H * C) / K  # Second radiation constant
+# Precise calculation
+# ```
+# H = 6.62607015e-34  # Plank's constant: `m2 kg / s`
+# C = 299792458  # Speed of light: `m / s`
+# K = 1.380649e-23  # Boltzmann constant: `m2 kg s-2 K-1`
+# C1 = 2 * math.pi * H * C ** 2  # First radiation constant
+# C2 = (H * C) / K  # Second radiation constant
+# ```
+# ITS-90 Standard rounds to 6 decimal places
+C1 = 3.741771e-16
+C2 = 1.4388e-2
 
 
 def temp_to_uv_planckian_locus(
@@ -23,7 +28,9 @@ def temp_to_uv_planckian_locus(
     white: VectorLike,
     start: int = 360,
     end: int = 830,
-    step: int = 5
+    step: int = 5,
+    c1: float = C1,
+    c2: float = C2
 ) -> Vector:
     """
     Temperature to Planckian locus.
@@ -33,7 +40,7 @@ def temp_to_uv_planckian_locus(
     x = y = z = 0.0
 
     for wavelength in range(start, end + 1, step):
-        m = C1 * (wavelength ** -5) * (math.exp(C2 / (wavelength * temp)) - 1.0) ** -1
+        m = c1 * (wavelength ** -5) * (math.exp((c2 * 1e9) / (wavelength * temp)) - 1.0) ** -1
         x += m * cmfs[wavelength][0]
         y += m * cmfs[wavelength][1]
         z += m * cmfs[wavelength][2]

--- a/coloraide/temperature/robertson_1968.py
+++ b/coloraide/temperature/robertson_1968.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any, Sequence
 if TYPE_CHECKING:  # pragma: no cover
     from ..color import Color
 
-
 # Table for Robertson 1968 method
 # Data: reciprocal temperature, u, v, slope
 RUVT = [

--- a/tests/test_cct.py
+++ b/tests/test_cct.py
@@ -21,20 +21,20 @@ class TestOhno2013Temp(util.ColorAssertsPyTest):
 
         for duv in (-0.03, -0.02, -0.01, 0.0, 0.01, 0.02, 0.03):
             cct2, duv2 = Color.blackbody(cct, duv, space=None).cct()
-            assert math.isclose(cct2, cct, rel_tol=(0.00001 if cct < 96000 else 0.0001), abs_tol=0.000001)
+            assert math.isclose(cct2, cct, rel_tol=(0.00001 if cct < 86000 else 0.0001), abs_tol=0.000001)
             assert math.isclose(duv2, duv, rel_tol=0.000001, abs_tol=0.000001)
 
 
 class TestRobertson1968(util.ColorAssertsPyTest):
     """Test Robertson 1968."""
 
-    @pytest.mark.parametrize('cct', list(range(1000, 100000, 1000)))
+    @pytest.mark.parametrize('cct', list(range(1667, 100000, 1000)))
     def test_cct(self, cct):
         """Test CCT methods."""
 
         for duv in (-0.03, -0.02, -0.01, 0.0, 0.01, 0.02, 0.03):
             cct2, duv2 = Color.blackbody(cct, duv, space=None, method='robertson-1968').cct(method='robertson-1968')
-            assert math.isclose(cct2, cct, rel_tol=0.0001, abs_tol=0.00001)
+            assert math.isclose(cct2, cct, rel_tol=0.00001, abs_tol=0.00001)
             assert math.isclose(duv2, duv, rel_tol=0.00001, abs_tol=0.00001)
 
 
@@ -57,10 +57,10 @@ class TestOhno2013Color(util.ColorAssertsPyTest):
         """Test CCT methods."""
 
         cct, duv = Color(color).cct()
-        c = Color.blackbody(cct, duv)
+        c = Color.blackbody(cct, duv, space=None)
         cct2, duv2 = c.cct()
-        assert math.isclose(cct, cct2, abs_tol=0.05)
-        assert math.isclose(duv, duv2, abs_tol=0.05)
+        assert math.isclose(cct, cct2, rel_tol=0.00001, abs_tol=0.00001)
+        assert math.isclose(duv, duv2, rel_tol=0.00001, abs_tol=0.00001)
 
 
 class TestRobertson1968Color(util.ColorAssertsPyTest):
@@ -82,10 +82,10 @@ class TestRobertson1968Color(util.ColorAssertsPyTest):
         """Test CCT methods."""
 
         cct, duv = Color(color).cct(method='robertson-1968')
-        c = Color.blackbody(cct, duv, method='robertson-1968')
+        c = Color.blackbody(cct, duv, space=None, method='robertson-1968')
         cct2, duv2 = c.cct(method='robertson-1968')
-        assert math.isclose(cct, cct2, abs_tol=0.05)
-        assert math.isclose(duv, duv2, abs_tol=0.05)
+        assert math.isclose(cct, cct2, rel_tol=0.00001, abs_tol=0.00001)
+        assert math.isclose(duv, duv2, rel_tol=0.00001, abs_tol=0.00001)
 
 
 class TestCCTSpecificCases(util.ColorAsserts, unittest.TestCase):
@@ -105,7 +105,7 @@ class TestCCTSpecificCases(util.ColorAsserts, unittest.TestCase):
 
         self.assertColorEqual(
             Color.blackbody(2000, out_space='display-p3'),
-            Color('color(display-p3 0.93958 0.56696 0.22948)')
+            Color('color(display-p3 0.93958 0.56696 0.22947)')
         )
 
     def test_normalization_space(self):
@@ -121,7 +121,7 @@ class TestCCTSpecificCases(util.ColorAsserts, unittest.TestCase):
 
         self.assertColorEqual(
             Color.blackbody(2000, space=None),
-            Color('color(xyz-d65 1.2743 1 0.14524)')
+            Color('color(xyz-d65 1.2743 1 0.14523)')
         )
 
     def test_ohno_alternate_cmfs(self):
@@ -138,49 +138,17 @@ class TestCCTSpecificCases(util.ColorAsserts, unittest.TestCase):
         )
 
         srgbl = Custom.blackbody(5000)
-        self.assertColorEqual(srgbl, Color('color(srgb-linear 1 0.77909 0.61807)'))
-        self.assertEqual(srgbl.cct(), [5000.005435889316, 2.770957661628331e-08])
+        self.assertColorEqual(srgbl, Color('color(srgb-linear 1 0.77908 0.61805)'))
+        cct, duv = srgbl.cct()
+        assert math.isclose(cct, 5000.005435878293, rel_tol=1e-11, abs_tol=1e-11)
+        assert math.isclose(duv, 2.771032069214595e-08, rel_tol=1e-11, abs_tol=1e-11)
 
     def test_ohno_exact(self):
         """Test alternate CMFs."""
 
-        cct1 = Color('orange').cct()
-        self.assertEqual(cct1, [2424.0755046224285, 0.008069417819174918])
-        cct2 = Color('orange').cct(exact=True)
-        self.assertEqual(cct2, [2424.0755046224285, 0.008069417819174918])
-
-    def test_robertson_custom_table(self):
-        """Test that we can customize Robertson 1968 table."""
-
-        from coloraide.temperature import robertson_1968
-
-        ruvt = robertson_1968.RUVT.copy()
-        # Extend table to approximate down to 1000K
-        ruvt.extend(
-            [(625, 0.34507, 0.36053, 190.08359),
-             (650, 0.35281, 0.36044, 57.76589),
-             (675, 0.36044, 0.36026, 35.98515),
-             (700, 0.36795, 0.36002, 27.0978),
-             (725, 0.37534, 0.35972, 22.30492),
-             (750, 0.38261, 0.35937, 19.32952),
-             (775, 0.38976, 0.35897, 17.31839),
-             (800, 0.39677, 0.35855, 15.87963),
-             (825, 0.40365, 0.3581, 14.80795),
-             (850, 0.4104, 0.35763, 13.98541),
-             (875, 0.41701, 0.35715, 13.33938),
-             (900, 0.42348, 0.35665, 12.82271),
-             (925, 0.42982, 0.35615, 12.40342),
-             (950, 0.43602, 0.35564, 12.05908),
-             (975, 0.44208, 0.35513, 11.7735),
-             (1000, 0.44801, 0.35463, 11.53467)]
-        )
-
-        class Custom(Color):
-            CCT = 'robertson-1968'
-
-        Custom.register(
-            robertson_1968.Robertson1968(ruvt),
-            overwrite=True
-        )
-
-        self.assertEqual(Custom.blackbody(1000, space=None).cct(), [1000.0000000000002, -5.530370757932678e-17])
+        cct1, duv1 = Color('orange').cct()
+        assert math.isclose(cct1, 2424.1146637385255, rel_tol=1e-11, abs_tol=1e-11)
+        assert math.isclose(duv1, 0.008069417642630583, rel_tol=1e-11, abs_tol=1e-11)
+        cct2, duv2 = Color('orange').cct(exact=True)
+        assert math.isclose(cct2, 2424.1146637385255, rel_tol=1e-11, abs_tol=1e-11)
+        assert math.isclose(duv2, 0.008069417642630583, rel_tol=1e-11, abs_tol=1e-11)

--- a/tests/test_cct.py
+++ b/tests/test_cct.py
@@ -100,6 +100,22 @@ class TestCCTSpecificCases(util.ColorAsserts, unittest.TestCase):
         with self.assertRaises(ValueError):
             Color('blue').cct(method='bad')
 
+    def test_outside_gamut(self):
+        """Test temperature outside of gamut."""
+
+        self.assertColorEqual(
+            Color.blackbody(1500),
+            Color('color(srgb-linear 1 0.14969 0)')
+        )
+
+    def test_robertson_1968_invert_slope(self):
+        """Test colors on the side of the locus where the slope inverts from negative to positive."""
+
+        self.assertEqual(
+            Color('color(xyz-d65 1.4899 1 0.05398 / 1)').cct(method='robertson-1968'),
+            [1500.0170599230767, 4.871531092560021e-07]
+        )
+
     def test_output_space(self):
         """Test output space."""
 

--- a/tests/test_cct.py
+++ b/tests/test_cct.py
@@ -144,7 +144,7 @@ class TestCCTSpecificCases(util.ColorAsserts, unittest.TestCase):
         assert math.isclose(duv, 2.771032069214595e-08, rel_tol=1e-11, abs_tol=1e-11)
 
     def test_ohno_exact(self):
-        """Test alternate CMFs."""
+        """Test exact CMFs."""
 
         cct1, duv1 = Color('orange').cct()
         assert math.isclose(cct1, 2424.1146637385255, rel_tol=1e-11, abs_tol=1e-11)

--- a/tests/test_cct.py
+++ b/tests/test_cct.py
@@ -108,14 +108,6 @@ class TestCCTSpecificCases(util.ColorAsserts, unittest.TestCase):
             Color('color(srgb-linear 1 0.14969 0)')
         )
 
-    def test_robertson_1968_invert_slope(self):
-        """Test colors on the side of the locus where the slope inverts from negative to positive."""
-
-        self.assertEqual(
-            Color('color(xyz-d65 1.4899 1 0.05398 / 1)').cct(method='robertson-1968'),
-            [1500.0170599230767, 4.871531092560021e-07]
-        )
-
     def test_output_space(self):
         """Test output space."""
 
@@ -168,3 +160,39 @@ class TestCCTSpecificCases(util.ColorAsserts, unittest.TestCase):
         cct2, duv2 = Color('orange').cct(exact=True)
         assert math.isclose(cct2, 2424.1146637385255, rel_tol=1e-11, abs_tol=1e-11)
         assert math.isclose(duv2, 0.008069417642630583, rel_tol=1e-11, abs_tol=1e-11)
+
+    def test_robertson_custom_table(self):
+        """Test that we can customize Robertson 1968 table."""
+
+        from coloraide.temperature import robertson_1968
+
+        ruvt = robertson_1968.RUVT.copy()
+        # Extend table to approximate down to 1000K
+        ruvt.extend(
+            [(625.0, 0.34508, 0.36053, 189.78),
+             (650.0, 0.35281, 0.36044, 57.748),
+             (675.0, 0.36044, 0.36026, 35.979),
+             (700.0, 0.36795, 0.36002, 27.095),
+             (725.0, 0.37535, 0.35972, 22.303),
+             (750.0, 0.38262, 0.35937, 19.328),
+             (775.0, 0.38976, 0.35897, 17.318),
+             (800.0, 0.39677, 0.35855, 15.879),
+             (825.0, 0.40366, 0.35810, 14.807),
+             (850.0, 0.41040, 0.35763, 13.985),
+             (875.0, 0.41701, 0.35715, 13.339),
+             (900.0, 0.42349, 0.35665, 12.822),
+             (925.0, 0.42983, 0.35615, 12.403),
+             (950.0, 0.43603, 0.35564, 12.059),
+             (975.0, 0.44209, 0.35513, 11.773),
+             (1000.0, 0.44801, 0.35462, 11.535)]
+        )
+
+        class Custom(Color):
+            CCT = 'robertson-1968'
+
+        Custom.register(
+            robertson_1968.Robertson1968(ruvt),
+            overwrite=True
+        )
+
+        self.assertEqual(Custom.blackbody(1000, space=None).cct(), [1000.0, 0.0])


### PR DESCRIPTION
We should use the recommended C2 constant for CCT as recommended in ITS-90. The difference is simply that the constant is rounded to 6 places and affects values slightly.