### PR TITLE
Fix inv row sorting once and for all

### DIFF
--- a/docs/src/py/notebook.py
+++ b/docs/src/py/notebook.py
@@ -362,7 +362,7 @@ def evaluate(node, g, loop=False):
             try:
                 for n in node.body:
                     yield from evaluate(n, g, True)
-            except Break:  # noqa:  PERF203
+            except Break:  # noqa
                 break
             except Continue:
                 continue
@@ -379,7 +379,7 @@ def evaluate(node, g, loop=False):
             try:
                 for n in node.body:
                     yield from evaluate(n, g, True)
-            except Break:  # noqa:  PERF203
+            except Break:  # noqa
                 break
             except Continue:
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,8 @@ ignore = [
     "N818",
     "RUF012",
     "RUF005",
-    "PGH004"
+    "PGH004",
+    "RUF100"
 ]
 
 [tool.tox]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,8 @@ ignore = [
     "N806",
     "N818",
     "RUF012",
-    "RUF005"
+    "RUF005",
+    "PGH004"
 ]
 
 [tool.tox]


### PR DESCRIPTION
We should now be able to sort the rows such that the diagonal never have zeros in them unless the matrix is invertible. We seem to be able to handle 30 x 30 2D matrices, much larger than we would ever need. There are certainly cases that could stress this, but from the perspective of what we need for colors, this should be good enough.