### PR TITLE
Fix some delta-e issues and expose config options

### DIFF
--- a/coloraide/distance/delta_e_2000.py
+++ b/coloraide/distance/delta_e_2000.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import math
 from ..distance import DeltaE
+from ..spaces.lab import CIELab
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -12,26 +13,30 @@ class DE2000(DeltaE):
     """Delta E 2000 class."""
 
     NAME = "2000"
-
-    # CSS uses D50 because that is the only Lab in the spec,
-    # but most implementation use D65. Typically D50 is the
-    # choice for reflective (i.e. Paper) or transmissive readings,
-    # while displays would typically use a measured white reference,
-    # or D65. If a CSS compliant variant is desired, simply subclass
-    # and set `LAB` to `lab-d50`. If the intent is not to override,
-    # then set `NAME` to something like `NAME="2000-D50"`.
-    LAB = "lab-d65"
-
     G_CONST = 25 ** 7
 
-    @classmethod
-    def distance(
-        cls,
-        color: Color,
-        sample: Color,
+    def __init__(
+        self,
         kl: float = 1,
         kc: float = 1,
         kh: float = 1,
+        space: str = 'lab-d65'
+    ):
+        """Initialize."""
+
+        self.kl = kl
+        self.kc = kc
+        self.kh = kh
+        self.space = space
+
+    def distance(
+        self,
+        color: Color,
+        sample: Color,
+        kl: float | None = None,
+        kc: float | None = None,
+        kh: float | None = None,
+        space: str | None = None,
         **kwargs: Any
     ) -> float:
         """
@@ -43,8 +48,22 @@ class DE2000(DeltaE):
         http://www2.ece.rochester.edu/~gsharma/ciede2000/ciede2000noteCRNA.pdf
         """
 
-        l1, a1, b1 = color.convert(cls.LAB).coords(nans=False)
-        l2, a2, b2 = sample.convert(cls.LAB).coords(nans=False)
+        if kl is None:
+            kl = self.kl
+
+        if kc is None:
+            kc = self.kc
+
+        if kh is None:
+            kh = self.kh
+
+        if space is None:
+            space = self.space
+        if not isinstance(color.CS_MAP[space], CIELab):
+            raise ValueError("Distance color space must be a CIE Lab color space.")
+
+        l1, a1, b1 = color.convert(space).coords(nans=False)
+        l2, a2, b2 = sample.convert(space).coords(nans=False)
 
         # Equation (2)
         c1 = math.sqrt(a1 ** 2 + b1 ** 2)
@@ -55,7 +74,7 @@ class DE2000(DeltaE):
 
         # Equation (4)
         c7 = cm ** 7
-        g = 0.5 * (1 - math.sqrt(c7 / (c7 + cls.G_CONST)))
+        g = 0.5 * (1 - math.sqrt(c7 / (c7 + self.G_CONST)))
 
         # Equation (5)
         ap1 = (1 + g) * a1
@@ -124,7 +143,7 @@ class DE2000(DeltaE):
 
         # Equation (17)
         cpm7 = cpm ** 7
-        rc = 2 * math.sqrt(cpm7 / (cpm7 + cls.G_CONST))
+        rc = 2 * math.sqrt(cpm7 / (cpm7 + self.G_CONST))
 
         # Equation (18)
         l_temp = (lpm - 50) ** 2

--- a/coloraide/distance/delta_e_76.py
+++ b/coloraide/distance/delta_e_76.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from ..distance import DeltaE, distance_euclidean
 from typing import TYPE_CHECKING, Any
-
+from ..spaces.lab import CIELab
 if TYPE_CHECKING:  # pragma: no cover
     from ..color import Color
 
@@ -11,9 +11,19 @@ class DE76(DeltaE):
     """Delta E 76 class."""
 
     NAME = "76"
-    SPACE = "lab-d65"
 
-    def distance(self, color: Color, sample: Color, **kwargs: Any) -> float:
+    def __init__(self, space: str = 'lab-d65'):
+        """Initialize."""
+
+        self.space = space
+
+    def distance(
+        self,
+        color: Color,
+        sample: Color,
+        space: str | None = None,
+        **kwargs: Any
+    ) -> float:
         """
         Delta E 1976 color distance formula.
 
@@ -22,5 +32,10 @@ class DE76(DeltaE):
         Basically this is Euclidean distance in the Lab space.
         """
 
+        if space is None:
+            space = self.space
+        if not isinstance(color.CS_MAP[space], CIELab):
+            raise ValueError("Distance color space must be a CIE Lab color space.")
+
         # Equation (1)
-        return distance_euclidean(color, sample, space=self.SPACE)
+        return distance_euclidean(color, sample, space=space)

--- a/coloraide/distance/delta_e_94.py
+++ b/coloraide/distance/delta_e_94.py
@@ -1,6 +1,7 @@
 """Delta E 94."""
 from __future__ import annotations
 from ..distance import DeltaE
+from ..spaces.lab import CIELab
 import math
 from typing import TYPE_CHECKING, Any
 
@@ -12,19 +13,20 @@ class DE94(DeltaE):
     """Delta E 94 class."""
 
     NAME = "94"
-    LAB = 'lab-d65'
 
     def __init__(
         self,
         kl: float = 1,
         k1: float = 0.045,
-        k2: float = 0.015
+        k2: float = 0.015,
+        space: str = 'lab-d65'
     ):
         """Initialize."""
 
         self.kl = kl
         self.k1 = k1
         self.k2 = k2
+        self.space = space
 
     def distance(
         self,
@@ -33,6 +35,7 @@ class DE94(DeltaE):
         kl: float | None = None,
         k1: float | None = None,
         k2: float | None = None,
+        space: str | None = None,
         **kwargs: Any
     ) -> float:
         """
@@ -50,8 +53,13 @@ class DE94(DeltaE):
         if k2 is None:
             k2 = self.k2
 
-        l1, a1, b1 = color.convert(self.LAB).coords(nans=False)
-        l2, a2, b2 = sample.convert(self.LAB).coords(nans=False)
+        if space is None:
+            space = self.space
+        if not isinstance(color.CS_MAP[space], CIELab):
+            raise ValueError("Distance color space must be a CIE Lab color space.")
+
+        l1, a1, b1 = color.convert(space).coords(nans=False)
+        l2, a2, b2 = sample.convert(space).coords(nans=False)
 
         # Equation (5)
         c1 = math.sqrt(a1 ** 2 + b1 ** 2)

--- a/coloraide/distance/delta_e_99o.py
+++ b/coloraide/distance/delta_e_99o.py
@@ -4,11 +4,19 @@ Delta E 99o.
 https://de.wikipedia.org/wiki/DIN99-Farbraum
 """
 from __future__ import annotations
-from .delta_e_76 import DE76
+from ..distance import DeltaE, distance_euclidean
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..color import Color
 
 
-class DE99o(DE76):
+class DE99o(DeltaE):
     """Delta E 99o class."""
 
-    NAME = "99o"
-    SPACE = "din99o"
+    NAME = '99o'
+
+    def distance(self, color: Color, sample: Color, **kwargs: Any) -> float:
+        """Get delta E 99o."""
+
+        return distance_euclidean(color, sample, space='din99o')

--- a/coloraide/distance/delta_e_cmc.py
+++ b/coloraide/distance/delta_e_cmc.py
@@ -1,6 +1,7 @@
 """Delta E CMC."""
 from __future__ import annotations
 from ..distance import DeltaE
+from ..spaces.lab import CIELab
 import math
 from typing import TYPE_CHECKING, Any
 
@@ -12,17 +13,18 @@ class DECMC(DeltaE):
     """Delta E CMC class."""
 
     NAME = "cmc"
-    LAB = 'lab-d65'
 
     def __init__(
         self,
         l: float = 2,
-        c: float = 1
+        c: float = 1,
+        space: str = 'lab-d65'
     ):
         """Initialize."""
 
         self.l = l
         self.c = c
+        self.space = space
 
     def distance(
         self,
@@ -30,6 +32,7 @@ class DECMC(DeltaE):
         sample: Color,
         l: float | None = None,
         c: float | None = None,
+        space: str | None = None,
         **kwargs: Any
     ) -> float:
         """
@@ -44,8 +47,13 @@ class DECMC(DeltaE):
         if c is None:
             c = self.c
 
-        l1, a1, b1 = color.convert(self.LAB).coords(nans=False)
-        l2, a2, b2 = sample.convert(self.LAB).coords(nans=False)
+        if space is None:
+            space = self.space
+        if not isinstance(color.CS_MAP[space], CIELab):
+            raise ValueError("Distance color space must be a CIE Lab color space.")
+
+        l1, a1, b1 = color.convert(space).coords(nans=False)
+        l2, a2, b2 = sample.convert(space).coords(nans=False)
 
         # Equation (3)
         c1 = math.sqrt(a1 ** 2 + b1 ** 2)

--- a/coloraide/distance/delta_e_ok.py
+++ b/coloraide/distance/delta_e_ok.py
@@ -1,17 +1,17 @@
 """Delta E OK."""
 from __future__ import annotations
-from .delta_e_76 import DE76
+from __future__ import annotations
+from ..distance import DeltaE, distance_euclidean
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..color import Color
 
 
-class DEOK(DE76):
-    """Delta E OK class."""
+class DEOK(DeltaE):
+    """Delta E 99o class."""
 
-    NAME = "ok"
-    SPACE = "oklab"
+    NAME = 'ok'
 
     def __init__(self, scalar: float = 1) -> None:
         """Initialize."""
@@ -28,5 +28,4 @@ class DEOK(DE76):
         if scalar is None:
             scalar = self.scalar
 
-        # Equation (1)
-        return scalar * super().distance(color, sample)
+        return scalar * distance_euclidean(color, sample, space='oklab')

--- a/coloraide/gamut/fit_hct_chroma.py
+++ b/coloraide/gamut/fit_hct_chroma.py
@@ -11,6 +11,7 @@ class HCTChroma(LChChroma):
     EPSILON = 0.001
     LIMIT = 0.02
     DE = "hct"
+    DE_OPTIONS = {}
     SPACE = "hct"
     MIN_LIGHTNESS = 0
     MAX_LIGHTNESS = 100

--- a/coloraide/gamut/fit_lch_chroma.py
+++ b/coloraide/gamut/fit_lch_chroma.py
@@ -34,7 +34,7 @@ class LChChroma(Fit):
     EPSILON = 0.1
     LIMIT = 2.0
     DE = "2000"
-    DE_OPTIONS = {}  # type: dict[str, Any]
+    DE_OPTIONS = {'space': 'lab-d65'}  # type: dict[str, Any]
     SPACE = "lch-d65"
     MIN_LIGHTNESS = 0
     MAX_LIGHTNESS = 100

--- a/coloraide/gamut/fit_oklch_chroma.py
+++ b/coloraide/gamut/fit_oklch_chroma.py
@@ -11,5 +11,6 @@ class OkLChChroma(LChChroma):
     EPSILON = 0.0001
     LIMIT = 0.02
     DE = "ok"
+    DE_OPTIONS = {}
     SPACE = "oklch"
     MAX_LIGHTNESS = 1

--- a/coloraide/spaces/lab/__init__.py
+++ b/coloraide/spaces/lab/__init__.py
@@ -34,7 +34,7 @@ def lab_to_xyz(lab: Vector, white: VectorLike) -> Vector:
     # compute `xyz`
     xyz = [
         fx ** 3 if fx > EPSILON3 else (116 * fx - 16) / KAPPA,
-        fy ** 3 if l > KE else l / KAPPA,
+        fy ** 3 if fy > EPSILON3 else (116 * fy - 16) / KAPPA,
         fz ** 3 if fz > EPSILON3 else (116 * fz - 16) / KAPPA
     ]
 
@@ -67,18 +67,14 @@ def xyz_to_lab(xyz: Vector, white: VectorLike) -> Vector:
 class Lab(Labish, Space):
     """Lab class."""
 
-    BASE = "xyz-d50"
-    NAME = "lab"
-    SERIALIZE = ("--lab",)
     CHANNELS = (
-        Channel("l", 0.0, 100.0, flags=FLG_OPT_PERCENT),
-        Channel("a", -125.0, 125.0, flags=FLG_MIRROR_PERCENT | FLG_OPT_PERCENT),
-        Channel("b", -125.0, 125.0, flags=FLG_MIRROR_PERCENT | FLG_OPT_PERCENT)
+        Channel("l", 0.0, 1.0),
+        Channel("a", 1.0, 1.0, flags=FLG_MIRROR_PERCENT),
+        Channel("b", 1.0, 1.0, flags=FLG_MIRROR_PERCENT)
     )
     CHANNEL_ALIASES = {
         "lightness": "l"
     }
-    WHITE = WHITES['2deg']['D50']
 
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
@@ -94,3 +90,17 @@ class Lab(Labish, Space):
         """From XYZ D50 to Lab."""
 
         return xyz_to_lab(coords, util.xy_to_xyz(self.white()))
+
+
+class CIELab(Lab):
+    """CIE Lab D50."""
+
+    BASE = "xyz-d50"
+    NAME = "lab"
+    SERIALIZE = ("--lab",)
+    CHANNELS = (
+        Channel("l", 0.0, 100.0, flags=FLG_OPT_PERCENT),
+        Channel("a", -125.0, 125.0, flags=FLG_MIRROR_PERCENT | FLG_OPT_PERCENT),
+        Channel("b", -125.0, 125.0, flags=FLG_MIRROR_PERCENT | FLG_OPT_PERCENT)
+    )
+    WHITE = WHITES['2deg']['D50']

--- a/coloraide/spaces/lab/css.py
+++ b/coloraide/spaces/lab/css.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ...color import Color
 
 
-class Lab(base.Lab):
+class Lab(base.CIELab):
     """Lab class."""
 
     def to_string(

--- a/coloraide/spaces/lab_d65.py
+++ b/coloraide/spaces/lab_d65.py
@@ -1,11 +1,11 @@
 """Lab D65 class."""
 from __future__ import annotations
 from ..cat import WHITES
-from .lab import Lab
+from .lab import CIELab
 from ..channels import Channel, FLG_MIRROR_PERCENT
 
 
-class LabD65(Lab):
+class LabD65(CIELab):
     """Lab D65 class."""
 
     BASE = 'xyz-d65'

--- a/coloraide/spaces/lch/__init__.py
+++ b/coloraide/spaces/lch/__init__.py
@@ -36,12 +36,9 @@ def lch_to_lab(lch: Vector) -> Vector:
 class LCh(LChish, Space):
     """LCh class."""
 
-    BASE = "lab"
-    NAME = "lch"
-    SERIALIZE = ("--lch",)
     CHANNELS = (
-        Channel("l", 0.0, 100.0, flags=FLG_OPT_PERCENT),
-        Channel("c", 0.0, 150.0, limit=(0.0, None), flags=FLG_OPT_PERCENT),
+        Channel("l", 0.0, 1.0, flags=FLG_OPT_PERCENT),
+        Channel("c", 0.0, 1.0, limit=(0.0, None), flags=FLG_OPT_PERCENT),
         Channel("h", 0.0, 360.0, flags=FLG_ANGLE)
     )
     CHANNEL_ALIASES = {
@@ -49,7 +46,6 @@ class LCh(LChish, Space):
         "chroma": "c",
         "hue": "h"
     }
-    WHITE = WHITES['2deg']['D50']
 
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
@@ -65,3 +61,22 @@ class LCh(LChish, Space):
         """From Lab to LCh."""
 
         return lab_to_lch(coords)
+
+
+class CIELCh(LCh):
+    """CIE LCh D50."""
+
+    BASE = "lab"
+    NAME = "lch"
+    SERIALIZE = ("--lch",)
+    CHANNELS = (
+        Channel("l", 0.0, 100.0, flags=FLG_OPT_PERCENT),
+        Channel("c", 0.0, 150.0, limit=(0.0, None), flags=FLG_OPT_PERCENT),
+        Channel("h", 0.0, 360.0, flags=FLG_ANGLE)
+    )
+    CHANNEL_ALIASES = {
+        "lightness": "l",
+        "chroma": "c",
+        "hue": "h"
+    }
+    WHITE = WHITES['2deg']['D50']

--- a/coloraide/spaces/lch/css.py
+++ b/coloraide/spaces/lch/css.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ...color import Color
 
 
-class LCh(base.LCh):
+class LCh(base.CIELCh):
     """LCh class."""
 
     def to_string(

--- a/coloraide/spaces/lch_d65.py
+++ b/coloraide/spaces/lch_d65.py
@@ -1,11 +1,11 @@
 """LCh D65 class."""
 from __future__ import annotations
 from ..cat import WHITES
-from .lch import LCh
+from .lch import CIELCh
 from ..channels import Channel, FLG_ANGLE
 
 
-class LChD65(LCh):
+class LChD65(CIELCh):
     """LCh D65 class."""
 
     BASE = "lab-d65"

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -6,7 +6,7 @@
 -   **NEW**: CIE Lab, both D50 and D65, are now derived from the `CIELab` class. CIE LCh, both D50 and D65, are also
     now derived from the `CIELCh` class. This makes it easy to determine a CIE Lab or CIE LCh space from other Lab-like
     spaces.
--   **NEW**: ∆E^\*^~76~, ∆E^\*^~94~, ∆E^\*^~00~, and ∆E^\*^~cmc~ all accept a new parameter called `cielab` which allows
+-   **NEW**: ∆E^\*^~76~, ∆E^\*^~94~, ∆E^\*^~00~, and ∆E^\*^~cmc~ all accept a new parameter called `space` which allows
     the user to specify a registered Lab color space name (one that is derived from the `CIELab` class) to use as the
     distancing color space. This allows a user to use D50 Lab (or any other variant) for distancing.
 -   **FIX**: For consistency, ∆E^\*^~94~ and ∆E^\*^~cmc~ now use Lab D65 by default just like ∆E^\*^~76~ and

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,11 +3,15 @@
 ## 2.10
 
 -   **NEW**: Declare official support for Python 3.12.
--   **NEW**: Make it easy to override CIE Lab variant used by ∆E^\*^~94~, ∆E^\*^~00~, and ∆E^\*^~cmc~.
--   **FIX**: ∆E^\*^~cmc~ should use Lab D65 (not D50) as it was originally designed for and now matches the
-    documentation.
--   **FIX**: For consistency, ∆E^\*^~94~ should use Lab D65 by default just like ∆E^\*^~76~ and ∆E^\*^~00~. This also
-    makes the implementation match what we reference in the documentation.
+-   **NEW**: CIE Lab, both D50 and D65, are now derived from the `CIELab` class. CIE LCh, both D50 and D65, are also
+    now derived from the `CIELCh` class. This makes it easy to determine a CIE Lab or CIE LCh space from other Lab-like
+    spaces.
+-   **NEW**: ∆E^\*^~76~, ∆E^\*^~94~, ∆E^\*^~00~, and ∆E^\*^~cmc~ all accept a new parameter called `cielab` which allows
+    the user to specify a registered Lab color space name (one that is derived from the `CIELab` class) to use as the
+    distancing color space. This allows a user to use D50 Lab (or any other variant) for distancing.
+-   **FIX**: For consistency, ∆E^\*^~94~ and ∆E^\*^~cmc~ now use Lab D65 by default just like ∆E^\*^~76~ and
+    ∆E^\*^~00~. This was fixes an issue where the docs indicated that they use D65, but in actuality they were using
+    D50.
 
 ## 2.9.1.post1
 

--- a/docs/src/markdown/distance.md
+++ b/docs/src/markdown/distance.md
@@ -52,10 +52,20 @@ It should be noted that not all distancing algorithms are symmetrical. Some are 
 
 Delta\ E                                 | Symmetrical           | Name            | Parameters
 ---------------------------------------- | --------------------- | --------------- | ----------
-[∆E^\*^~ab~][de76]\ (CIE76)              | :octicons-check-16:   | `76`            |
+[∆E^\*^~ab~][de76]\ (CIE76)              | :octicons-check-16:   | `76`            | `space='lab-d65'`
 
 One of the first approaches to color distancing and is actually just Euclidean distancing in the [CIELab](./colors/lab_d65.md)
 color space.
+
+/// note
+By default, Lab D65 is used for color distancing. In the print industry, it is common for Lab D50 to be used. If Lab
+D50 is desired, simply specify it as the `space` color space. `space` must be a CIE Lab color space.
+
+```py play
+Color("red").delta_e("blue", method="76")
+Color("red").delta_e("blue", method="76", space='lab')
+```
+///
 
 ### Delta E CMC (1984)
 
@@ -64,7 +74,7 @@ color space.
 
 Delta\ E                                 | Symmetrical           | Name            | Parameters
 ---------------------------------------- | --------------------- | --------------- | ----------
-[∆E^\*^~cmc~][decmc]\ (CMC\ l:c\ (1984)) | :octicons-check-16:   | `cmc`           | `l=2, c=1`
+[∆E^\*^~cmc~][decmc]\ (CMC\ l:c\ (1984)) | :octicons-check-16:   | `cmc`           | `l=2, c=1, space='lab-d65'`
 
 Delta E CMC is based on the [CIELCh](./colors/lch_d65.md) color space. The CMC calculation mathematically defines an
 ellipsoid around the standard color with semi-axis corresponding to hue, chroma and lightness.
@@ -74,6 +84,16 @@ Parameter | Acceptability | Perceptibility
 `l`       | 2             | 1
 `c`       | 1             | 1
 
+/// note
+By default, Lab D65 is used for color distancing. In the print industry, it is common for Lab D50 to be used. If Lab
+D50 is desired, simply specify it as the `space` color space. `space` must be a CIE Lab color space.
+
+```py play
+Color("red").delta_e("blue", method="cmc")
+Color("red").delta_e("blue", method="cmc", space='lab')
+```
+///
+
 ### Delta E CIE94
 
 /// success | The ∆E~94~ distancing algorithm is registered in `Color` by default
@@ -81,7 +101,7 @@ Parameter | Acceptability | Perceptibility
 
 Delta\ E                                 | Symmetrical           | Name            | Parameters
 ---------------------------------------- | --------------------- | --------------- | ----------
-[∆E^\*^~94~][de94]\ (CIE94)              | :octicons-x-16:       | `94`            | `kl=1, k1=0.045, k2=0.015`
+[∆E^\*^~94~][de94]\ (CIE94)              | :octicons-x-16:       | `94`            | `kl=1, k1=0.045, k2=0.015, space='lab-d65'`
 
 The [1976](#delta-e-cie76) definition was extended to address perceptual non-uniformities, while retaining the
 [CIELab](./colors/lab_d65.md) color space, by the introduction of application-specific weights derived from an
@@ -93,6 +113,16 @@ Parameter | Graphic\ Arts | Textiles
 `k1`      | 0.045         | 0.048
 `k2`      | 0.015         | 0.014
 
+/// note
+By default, Lab D65 is used for color distancing. In the print industry, it is common for Lab D50 to be used. If Lab
+D50 is desired, simply specify it as the `space` color space. `space` must be a CIE Lab color space.
+
+```py play
+Color("red").delta_e("blue", method="94")
+Color("red").delta_e("blue", method="94", space='lab')
+```
+///
+
 ### Delta E CIEDE2000
 
 /// success | The ∆E~00~ distancing algorithm is registered in `Color` by default
@@ -100,7 +130,7 @@ Parameter | Graphic\ Arts | Textiles
 
 Delta\ E                                 | Symmetrical           | Name            | Parameters
 ---------------------------------------- | --------------------- | --------------- | ----------
-[∆E^\*^~00~][de2000]\ (CIEDE2000)        | :octicons-check-16:   | `2000`          | `kl=1, kc=1, kh=1`
+[∆E^\*^~00~][de2000]\ (CIEDE2000)        | :octicons-check-16:   | `2000`          | `kl=1, kc=1, kh=1, space='lab-d65'`
 
 Since the 1994 definition did not adequately resolve the perceptual uniformity issue, the CIE refined their definition,
 adding five corrections:
@@ -110,6 +140,16 @@ adding five corrections:
 - Compensation for lightness (SL)
 - Compensation for chroma (SC)
 - Compensation for hue (SH)
+
+/// note
+By default, Lab D65 is used for color distancing. In the print industry, it is common for Lab D50 to be used. If Lab
+D50 is desired, simply specify it as the `space` color space. `space` must be a CIE Lab color space.
+
+```py play
+Color("red").delta_e("blue", method="2000")
+Color("red").delta_e("blue", method="2000", space='lab')
+```
+///
 
 ### Delta E HyAB
 
@@ -278,4 +318,24 @@ The default distancing method is used if one is not supplied, but others can be 
 
 ```py play
 Color('red').closest(['pink', 'yellow', 'green', 'blue', 'purple', 'maroon'], method='2000')
+```
+
+## Configuring Delta E Defaults
+
+A number of distancing algorithms have configurable features that can be set on demand. If you'd like to have these
+options set by default, you create a custom class and register the the plugins with the defaults of your choice.
+
+In this example, we will configure ∆E~00~ to use CIE Lab D50 instead of D65 by default.
+
+```py play
+from coloraide import Color as Base
+from coloraide.distance.delta_e_2000 import DE2000
+
+class Color(Base):
+    ...
+
+Color.register(DE2000(space='lab'), overwrite=True)
+
+Color('red').delta_e('blue', method='2000')
+Color('red').delta_e('blue', method='2000', space='lab-d65')
 ```

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -257,6 +257,34 @@ class TestDistance(util.ColorAssertsPyTest):
         'color1,color2,value',
         [
             ('red', 'red', 0),
+            ('red', 'orange', 58.1253),
+            ('red', 'yellow', 108.4044),
+            ('red', 'green', 130.3599),
+            ('red', 'blue', 184.019),
+            ('red', 'indigo', 133.2445),
+            ('red', 'violet', 110.9902),
+            ('red', 'black', 119.8401),
+            ('red', 'white', 116.2047),
+            ('red', 'gray', 106.8395),
+            # Pythagorean 3, 4, 5 triangle
+            ('color(--lab 50% 30 40)', 'color(--lab 50% 0 0)', 50),
+        ]
+    )
+    def test_delta_e_76_d50(self, color1, color2, value):
+        """Test delta e 76 D50."""
+
+        print('color1: ', color1)
+        print('color2: ', color2)
+        self.assertCompare(
+            Color(color1).delta_e(color2, method="76", space='lab'),
+            value,
+            rounding=4
+        )
+
+    @pytest.mark.parametrize(
+        'color1,color2,value',
+        [
+            ('red', 'red', 0),
             ('red', 'orange', 30.1848),
             ('red', 'yellow', 59.9971),
             ('red', 'green', 50.9748),
@@ -294,6 +322,34 @@ class TestDistance(util.ColorAssertsPyTest):
     @pytest.mark.parametrize(
         'color1,color2,value',
         [
+            ('red', 'red', 0),
+            ('red', 'orange', 28.6827),
+            ('red', 'yellow', 57.5928),
+            ('red', 'green', 48.8419),
+            ('red', 'blue', 73.8268),
+            ('red', 'indigo', 59.1223),
+            ('red', 'violet', 42.5283),
+            ('red', 'black', 57.3225),
+            ('red', 'white', 49.2723),
+            ('red', 'gray', 18.4094),
+            # Pythagorean 3, 4, 5 triangle
+            ('color(--lab 50% 30 40)', 'color(--lab 50% 0 0)', 15.3846),
+        ]
+    )
+    def test_delta_e_94_d50(self, color1, color2, value):
+        """Test delta e 94 D50."""
+
+        print('color1: ', color1)
+        print('color2: ', color2)
+        self.assertCompare(
+            Color(color1).delta_e(color2, method="94", space='lab'),
+            value,
+            rounding=4
+        )
+
+    @pytest.mark.parametrize(
+        'color1,color2,value',
+        [
             ('red', 'red', 0.0),
             ('red', 'orange', 35.0602),
             ('red', 'yellow', 68.462),
@@ -315,7 +371,7 @@ class TestDistance(util.ColorAssertsPyTest):
             ('white', 'red', 164.6293),
             ('gray', 'red', 163.8716),
             # Pythagorean 3, 4, 5 triangle
-            ('lab(50% 30 40)', 'lab(50% 0 0)', 19.1396),
+            ('color(--lab-d65 50% 30 40)', 'color(--lab-d65 50% 0 0)', 19.4894),
             # Brilliant red
             ('lab(38.64% 64.26 52.16)', 'lab(38.59% 62.06 51.11)', 0.882),
             ('lab(38.83% 33.35 26.67)', 'lab(38.69% 31.14 25.21)', 1.1444),
@@ -332,6 +388,34 @@ class TestDistance(util.ColorAssertsPyTest):
         print('color2: ', color2)
         self.assertCompare(
             Color(color1).delta_e(color2, method="cmc"),
+            value,
+            rounding=4
+        )
+
+    @pytest.mark.parametrize(
+        'color1,color2,value',
+        [
+            ('red', 'red', 0),
+            ('red', 'orange', 32.7965),
+            ('red', 'yellow', 64.9048),
+            ('red', 'green', 78.8614),
+            ('red', 'blue', 114.2301),
+            ('red', 'indigo', 79.8767),
+            ('red', 'violet', 65.2371),
+            ('red', 'black', 38.9135),
+            ('red', 'white', 36.7155),
+            ('red', 'gray', 30.7143),
+            # Pythagorean 3, 4, 5 triangle
+            ('color(--lab 50% 30 40)', 'color(--lab 50% 0 0)', 19.4894),
+        ]
+    )
+    def test_delta_e_cmc_d50(self, color1, color2, value):
+        """Test delta e CMC D50."""
+
+        print('color1: ', color1)
+        print('color2: ', color2)
+        self.assertCompare(
+            Color(color1).delta_e(color2, method="cmc", space='lab'),
             value,
             rounding=4
         )
@@ -441,6 +525,34 @@ class TestDistance(util.ColorAssertsPyTest):
         print('color2: ', color2)
         self.assertCompare(
             Color(color1).delta_e(color2, method="2000"),
+            value,
+            rounding=4
+        )
+
+    @pytest.mark.parametrize(
+        'color1,color2,value',
+        [
+            ('red', 'red', 0),
+            ('red', 'orange', 31.4666),
+            ('red', 'yellow', 60.9841),
+            ('red', 'green', 70.2367),
+            ('red', 'blue', 55.7998),
+            ('red', 'indigo', 52.847),
+            ('red', 'violet', 41.6922),
+            ('red', 'black', 51.3402),
+            ('red', 'white', 45.2646),
+            ('red', 'gray', 31.4011),
+            # Pythagorean 3, 4, 5 triangle
+            ('color(--lab 50% 30 40)', 'color(--lab 50% 0 0)', 24.1219),
+        ]
+    )
+    def test_delta_e_2000_d50(self, color1, color2, value):
+        """Test delta e 2000 D50."""
+
+        print('color1: ', color1)
+        print('color2: ', color2)
+        self.assertCompare(
+            Color(color1).delta_e(color2, method="2000", space='lab'),
             value,
             rounding=4
         )
@@ -650,6 +762,30 @@ class TestDistanceSpecificCases(util.ColorAsserts, unittest.TestCase):
 
         with self.assertRaises(ValueError):
             Color('red').delta_e('orange', method="hyab", space="lch")
+
+    def test_76_bad_space(self):
+        """Test 76 bad space."""
+
+        with self.assertRaises(ValueError):
+            Color('red').delta_e('orange', method="76", space="oklab")
+
+    def test_94_bad_space(self):
+        """Test 94 bad space."""
+
+        with self.assertRaises(ValueError):
+            Color('red').delta_e('orange', method="94", space="oklab")
+
+    def test_2000_bad_space(self):
+        """Test 2000 bad space."""
+
+        with self.assertRaises(ValueError):
+            Color('red').delta_e('orange', method="2000", space="oklab")
+
+    def test_cmc_bad_space(self):
+        """Test CMC bad space."""
+
+        with self.assertRaises(ValueError):
+            Color('red').delta_e('orange', method="cmc", space="oklab")
 
 
 class TestClosest(util.ColorAsserts, unittest.TestCase):


### PR DESCRIPTION
CIE Lab based delta E algorithms should allow specifying a specific CIE Lab variant (D50 vs D65, etc.)

We imply based on our references that all the CIE Lab algorithms are based on Lab D65, but CMC and 94 were using D50. Fix this inconsistency. If people want D50, we've now exposed ways to do this on demand or by setting it as the default.

Resolve #361