### PR TITLE
Gamut mapping fixes and adjustments

### DIFF
--- a/coloraide/color.py
+++ b/coloraide/color.py
@@ -583,7 +583,7 @@ class Color(metaclass=ColorMeta):
             method = None if not isinstance(fit, str) else fit
             if not self.in_gamut(space, tolerance=0.0):
                 converted = self.convert(space, in_place=in_place, norm=norm)
-                return converted.fit(space, method=method)
+                return converted.fit(method=method)
 
         # Nothing to do, just return the color with no alterations.
         if space == self.space():
@@ -853,15 +853,27 @@ class Color(metaclass=ColorMeta):
         """Clip the color channels."""
 
         orig_space = self.space()
+        clip_space = self._space.CLIP_SPACE
+        gamut_space = self._space.GAMUT_CHECK
         if space is None:
-            space = self.space()
+            space = clip_space or gamut_space or orig_space
+        else:
+            space = clip_space or gamut_space or space
 
-        # Convert to desired space
-        c = self.convert(space, in_place=True, norm=False)
-        gamut.clip_channels(c)
+        # Convert to desired space and clip the color
+        if space != orig_space:
+            conv = self.convert(space, norm=False)
+            if not gamut.clip_channels(conv):
+                # Clipping only made non-essential changes (normalize hue),
+                # just clip in the current space to preserve 'None' and clean up noise
+                # at color space boundary limits (if any).
+                gamut.clip_channels(self)
+                return self
+            # Copy results to current color.
+            return self._hotswap(conv.convert(orig_space, in_place=True))
 
-        # Adjust "this" color
-        return c.convert(orig_space, in_place=True)
+        gamut.clip_channels(self)
+        return self
 
     def fit(
         self,
@@ -881,7 +893,7 @@ class Color(metaclass=ColorMeta):
 
         orig_space = self.space()
         if space is None:
-            space = self.space()
+            space = self._space.GAMUT_CHECK or orig_space
 
         # Select appropriate mapping algorithm
         mapping = self.FIT_MAP.get(method)
@@ -890,18 +902,26 @@ class Color(metaclass=ColorMeta):
             raise ValueError("'{}' gamut mapping is not currently supported".format(method))
 
         # Convert to desired space
-        self.convert(space, in_place=True, norm=False)
+        if space != orig_space:
+            conv = self.convert(space, norm=False)
 
-        # If within gamut, just normalize hue range by calling clip.
+            # If within gamut, just normalize hue range by calling clip.
+            if conv.in_gamut(tolerance=0):
+                gamut.clip_channels(self)
+                return self
+
+            # Perform gamut mapping.
+            mapping.fit(conv, **kwargs)
+
+            # Convert back to the original color space
+            return self._hotswap(conv.convert(orig_space, in_place=True))
+
+        # Gamut map the color directly
         if self.in_gamut(tolerance=0):
             gamut.clip_channels(self)
-
-        # Perform gamut mapping.
-        else:
-            mapping.fit(self, **kwargs)
-
-        # Convert back to the original color space
-        return self.convert(orig_space, in_place=True)
+            return self
+        mapping.fit(self, **kwargs)
+        return self
 
     def in_gamut(self, space: str | None = None, *, tolerance: float = util.DEF_FIT_TOLERANCE) -> bool:
         """Check if current color is in gamut."""

--- a/coloraide/color.py
+++ b/coloraide/color.py
@@ -853,12 +853,11 @@ class Color(metaclass=ColorMeta):
         """Clip the color channels."""
 
         orig_space = self.space()
-        clip_space = self._space.CLIP_SPACE
-        gamut_space = self._space.GAMUT_CHECK
         if space is None:
-            space = clip_space or gamut_space or orig_space
+            space = self._space.CLIP_SPACE or self._space.GAMUT_CHECK or orig_space
         else:
-            space = clip_space or gamut_space or space
+            cs = self.CS_MAP[space]
+            space = cs.CLIP_SPACE or cs.GAMUT_CHECK or cs.NAME
 
         # Convert to desired space and clip the color
         if space != orig_space:
@@ -894,6 +893,9 @@ class Color(metaclass=ColorMeta):
         orig_space = self.space()
         if space is None:
             space = self._space.GAMUT_CHECK or orig_space
+        else:
+            cs = self.CS_MAP[space]
+            space = cs.GAMUT_CHECK or cs.NAME
 
         # Select appropriate mapping algorithm
         mapping = self.FIT_MAP.get(method)

--- a/coloraide/gamut/__init__.py
+++ b/coloraide/gamut/__init__.py
@@ -1,7 +1,6 @@
 """Gamut handling."""
 from __future__ import annotations
 import math
-from .. import algebra as alg
 from ..channels import FLG_ANGLE
 from abc import ABCMeta, abstractmethod
 from ..types import Plugin
@@ -15,8 +14,10 @@ if TYPE_CHECKING:  # pragma: no cover
 __all__ = ('clip_channels', 'verify', 'Fit', 'pointer')
 
 
-def clip_channels(color: Color, nans: bool = True) -> None:
+def clip_channels(color: Color, nans: bool = True) -> bool:
     """Clip channels."""
+
+    clipped = False
 
     for i, value in enumerate(color[:-1]):
 
@@ -32,7 +33,16 @@ def clip_channels(color: Color, nans: bool = True) -> None:
             continue
 
         # Fit value in bounds.
-        color[i] = alg.clamp(value, chan.low, chan.high)
+        if value < chan.low:
+            color[i] = chan.low
+        elif value > chan.high:
+            color[i] = chan.high
+        else:
+            continue
+
+        clipped = True
+
+    return clipped
 
 
 def verify(color: Color, tolerance: float) -> bool:

--- a/coloraide/harmonies.py
+++ b/coloraide/harmonies.py
@@ -106,6 +106,7 @@ class Harmony(metaclass=ABCMeta):
                 SERIALIZE = ('---harmoncy-cylinder',)
                 BASE = name
                 GAMUT_CHECK = name
+                CLIP_SPACE = None
                 WHITE = cs.WHITE
                 DYAMIC_RANGE = cs.DYNAMIC_RANGE
                 INDEXES = cs.indexes() if hasattr(cs, 'indexes') else [0, 1, 2]

--- a/coloraide/spaces/cubehelix.py
+++ b/coloraide/spaces/cubehelix.py
@@ -89,6 +89,7 @@ class Cubehelix(HSLish, Space):
         "lightness": "l"
     }
     WHITE = WHITES['2deg']['D65']
+    GAMUT_CHECK = 'srgb'
 
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""

--- a/coloraide/spaces/hsi.py
+++ b/coloraide/spaces/hsi.py
@@ -91,6 +91,7 @@ class HSI(HSV):
     }
     WHITE = WHITES['2deg']['D65']
     GAMUT_CHECK = "srgb"
+    CLIP_SPACE = None
 
     def to_base(self, coords: Vector) -> Vector:
         """To sRGB from HSI."""

--- a/coloraide/spaces/hsl/__init__.py
+++ b/coloraide/spaces/hsl/__init__.py
@@ -68,6 +68,7 @@ class HSL(HSLish, Space):
     }
     WHITE = WHITES['2deg']['D65']
     GAMUT_CHECK = "srgb"
+    CLIP_SPACE = "hsl"  # type: str | None
 
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""

--- a/coloraide/spaces/hsl/__init__.py
+++ b/coloraide/spaces/hsl/__init__.py
@@ -67,7 +67,7 @@ class HSL(HSLish, Space):
         "lightness": "l"
     }
     WHITE = WHITES['2deg']['D65']
-    GAMUT_CHECK = "srgb"
+    GAMUT_CHECK = "srgb"  # type: str | None
     CLIP_SPACE = "hsl"  # type: str | None
 
     def is_achromatic(self, coords: Vector) -> bool:

--- a/coloraide/spaces/hsluv.py
+++ b/coloraide/spaces/hsluv.py
@@ -120,6 +120,7 @@ class HSLuv(HSLish, Space):
     }
     WHITE = WHITES['2deg']['D65']
     GAMUT_CHECK = "srgb"
+    CLIP_SPACE = "hsluv"
 
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""

--- a/coloraide/spaces/hsv.py
+++ b/coloraide/spaces/hsv.py
@@ -53,6 +53,7 @@ class HSV(HSVish, Space):
         "value": "v"
     }
     GAMUT_CHECK = "srgb"
+    CLIP_SPACE = "hsv"  # type: str | None
     WHITE = WHITES['2deg']['D65']
 
     def is_achromatic(self, coords: Vector) -> bool:

--- a/coloraide/spaces/hsv.py
+++ b/coloraide/spaces/hsv.py
@@ -52,7 +52,7 @@ class HSV(HSVish, Space):
         "saturation": "s",
         "value": "v"
     }
-    GAMUT_CHECK = "srgb"
+    GAMUT_CHECK = "srgb"  # type: str | None
     CLIP_SPACE = "hsv"  # type: str | None
     WHITE = WHITES['2deg']['D65']
 

--- a/coloraide/spaces/okhsl.py
+++ b/coloraide/spaces/okhsl.py
@@ -471,7 +471,10 @@ class Okhsl(HSL):
     SERIALIZE = ("--okhsl",)
     CHANNELS = (
         Channel("h", 0.0, 360.0, bound=True, flags=FLG_ANGLE),
-        Channel("s", 0.0, 1.0, bound=True),
+        # We cannot be certain a saturation will fall on 1 or even under 1.
+        # This is a weakness of the Okhsl algorithm. Gamut mapping, including
+        # clipping, will be performed in sRGB for a more reliable, assured gamut.
+        Channel("s", 0.0, 1.0),
         Channel("l", 0.0, 1.0, bound=True)
     )
     CHANNEL_ALIASES = {
@@ -479,7 +482,7 @@ class Okhsl(HSL):
         "saturation": "s",
         "lightness": "l"
     }
-    CLIP_SPACE = 'okhsl'
+    CLIP_SPACE = None
 
     def to_base(self, coords: Vector) -> Vector:
         """To Oklab from Okhsl."""

--- a/coloraide/spaces/okhsl.py
+++ b/coloraide/spaces/okhsl.py
@@ -67,7 +67,7 @@ SRGBL_COEFF = [
         # Limit
         [0.13110758, 1.81333971],
         # `Kn` coefficients
-        [1.35691251, -0.00926975, -1.15076744, -0.50647251, 0.00645585]
+        [1.35733652, -0.00915799, -1.1513021, -0.50559606, 0.00692167]
     ]
 ]  # type: list[Matrix]
 
@@ -479,6 +479,7 @@ class Okhsl(HSL):
         "saturation": "s",
         "lightness": "l"
     }
+    CLIP_SPACE = 'okhsl'
 
     def to_base(self, coords: Vector) -> Vector:
         """To Oklab from Okhsl."""

--- a/coloraide/spaces/okhsl.py
+++ b/coloraide/spaces/okhsl.py
@@ -471,10 +471,7 @@ class Okhsl(HSL):
     SERIALIZE = ("--okhsl",)
     CHANNELS = (
         Channel("h", 0.0, 360.0, bound=True, flags=FLG_ANGLE),
-        # We cannot be certain a saturation will fall on 1 or even under 1.
-        # This is a weakness of the Okhsl algorithm. Gamut mapping, including
-        # clipping, will be performed in sRGB for a more reliable, assured gamut.
-        Channel("s", 0.0, 1.0),
+        Channel("s", 0.0, 1.0, bound=True),
         Channel("l", 0.0, 1.0, bound=True)
     )
     CHANNEL_ALIASES = {
@@ -482,6 +479,7 @@ class Okhsl(HSL):
         "saturation": "s",
         "lightness": "l"
     }
+    GAMUT_CHECK = None
     CLIP_SPACE = None
 
     def to_base(self, coords: Vector) -> Vector:

--- a/coloraide/spaces/okhsv.py
+++ b/coloraide/spaces/okhsv.py
@@ -153,6 +153,7 @@ class Okhsv(HSV):
         "saturation": "s",
         "value": "v"
     }
+    CLIP_SPACE = 'okhsv'
 
     def to_base(self, okhsv: Vector) -> Vector:
         """To Oklab from Okhsv."""

--- a/coloraide/spaces/okhsv.py
+++ b/coloraide/spaces/okhsv.py
@@ -145,7 +145,10 @@ class Okhsv(HSV):
     SERIALIZE = ("--okhsv",)
     CHANNELS = (
         Channel("h", 0.0, 360.0, bound=True, flags=FLG_ANGLE),
-        Channel("s", 0.0, 1.0, bound=True),
+        # We cannot be certain a saturation will fall on 1 or even under 1.
+        # This is a weakness of the Okhsv algorithm. Gamut mapping, including
+        # clipping, will be performed in sRGB for a more reliable, assured gamut.
+        Channel("s", 0.0, 1.0),
         Channel("v", 0.0, 1.0, bound=True)
     )
     CHANNEL_ALIASES = {
@@ -153,7 +156,7 @@ class Okhsv(HSV):
         "saturation": "s",
         "value": "v"
     }
-    CLIP_SPACE = 'okhsv'
+    CLIP_SPACE = None
 
     def to_base(self, okhsv: Vector) -> Vector:
         """To Oklab from Okhsv."""

--- a/coloraide/spaces/okhsv.py
+++ b/coloraide/spaces/okhsv.py
@@ -145,10 +145,7 @@ class Okhsv(HSV):
     SERIALIZE = ("--okhsv",)
     CHANNELS = (
         Channel("h", 0.0, 360.0, bound=True, flags=FLG_ANGLE),
-        # We cannot be certain a saturation will fall on 1 or even under 1.
-        # This is a weakness of the Okhsv algorithm. Gamut mapping, including
-        # clipping, will be performed in sRGB for a more reliable, assured gamut.
-        Channel("s", 0.0, 1.0),
+        Channel("s", 0.0, 1.0, bound=True),
         Channel("v", 0.0, 1.0, bound=True)
     )
     CHANNEL_ALIASES = {
@@ -156,6 +153,7 @@ class Okhsv(HSV):
         "saturation": "s",
         "value": "v"
     }
+    GAMUT_CHECK = None
     CLIP_SPACE = None
 
     def to_base(self, okhsv: Vector) -> Vector:

--- a/coloraide/spaces/orgb.py
+++ b/coloraide/spaces/orgb.py
@@ -74,6 +74,7 @@ class oRGB(Labish, Space):
     CHANNEL_ALIASES = {
         "luma": "l"
     }
+    GAMUT_CHECK = 'srgb'
 
     def to_base(self, coords: Vector) -> Vector:
         """To base from oRGB."""

--- a/coloraide/spaces/prismatic.py
+++ b/coloraide/spaces/prismatic.py
@@ -52,6 +52,8 @@ class Prismatic(Space):
         "blue": 'b'
     }
     WHITE = WHITES['2deg']['D65']
+    GAMUT_CHECK = 'srgb'
+    CLIP_SPACE = 'prismatic'
 
     def is_achromatic(self, coords: Vector) -> bool:
         """Test if color is achromatic."""

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+-   **NEW**: Color spaces that specify the gamut space via `GAMUT_CHECK` must use that color space as a reference when
+    when gamut mapping or clipping by default.
+-   **NEW**: New color space attribute `CLIP_SPACE` added which will override the space specified by `GAMUT_CHECK`.
+    Used to force clipping in origin space even if a gamut mapping space is defined if it is advantageous (faster and
+    still practical) to clip in the origin space.
 -   **NEW**: Deprecate non-standard CAM16 (Jab) space. People should use the standard CAM16 JMh or the CAM16 UCS, SCD,
     or LCD Jab spaces. The non-standard Jab is still available via `coloraide.spaces.cam16.CAM16`, but it is no longer
     available in `coloraide.everything` and will be removed at a future time.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -11,7 +11,7 @@
     or LCD Jab spaces. The non-standard Jab is still available via `coloraide.spaces.cam16.CAM16`, but it is no longer
     available in `coloraide.everything` and will be removed at a future time.
 -   **FIX**: The oRGB color space should be gamut mapped in `srgb` as it is a transform of the RGB space.
--   **FIX**: Okhsl and Okhsv must be clipped in sRGB.
+-   **FIX**: Okhsl and Okhsv have a rough sRGB approximation and are instead gamut mapped to their own gamut.
 -   **FIX**: Much more accurate ICtCp matrices.
 -   **FIX**: Fix typing of deeply nested arrays in `algebra`.
 -   **FIX**: Fix issue with HCT undefined channel resolver.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -10,6 +10,8 @@
 -   **NEW**: Deprecate non-standard CAM16 (Jab) space. People should use the standard CAM16 JMh or the CAM16 UCS, SCD,
     or LCD Jab spaces. The non-standard Jab is still available via `coloraide.spaces.cam16.CAM16`, but it is no longer
     available in `coloraide.everything` and will be removed at a future time.
+-   **FIX**: The oRGB color space should be gamut mapped in `srgb` as it is a transform of the RGB space.
+-   **FIX**: Okhsl and Okhsv must be clipped in sRGB.
 -   **FIX**: Much more accurate ICtCp matrices.
 -   **FIX**: Fix typing of deeply nested arrays in `algebra`.
 -   **FIX**: Fix issue with HCT undefined channel resolver.

--- a/docs/src/markdown/colors/okhsl.md
+++ b/docs/src/markdown/colors/okhsl.md
@@ -28,9 +28,9 @@ Okhsl color space in 3D
 /////
 ////
 
-Okhsl is a another color space created by Björn Ottosson. It is based off his early work and leverages the
-[Oklab](./oklab.md) color space. The aim was to create a color space that was better suited for being used in color pickers
-than the current HSL.
+Okhsl was created by Björn Ottosson and is a transform of the [Oklab](./oklab.md) color space that approximates the sRGB
+gamut perceptually in an HSL color model. The aim was to create a color space that was better suited for being used in
+color pickers than the current HSL.
 
 _[Learn about Okhsv](https://bottosson.github.io/posts/colorpicker/)_
 ///

--- a/docs/src/markdown/colors/okhsv.md
+++ b/docs/src/markdown/colors/okhsv.md
@@ -28,13 +28,12 @@ Okhsv color space in 3D
 /////
 ////
 
-Okhsv is a color space created by Björn Ottosson. It is based off his early work and leverages the [Oklab](./oklab.md) color
-space. The aim was to create a color space that was better suited for being used in color pickers than the current HSV.
+Okhsv was created by Björn Ottosson and is a transform of the [Oklab](./oklab.md) color space that approximates the sRGB
+gamut perceptually in an HSL color model. The aim was to create a color space that was better suited for being used in
+color pickers than the current HSV.
 
 _[Learn about Okhsv](https://bottosson.github.io/posts/colorpicker/)_
 ///
-
-??? abstract "ColorAide Details"
 
 ## Channel Aliases
 

--- a/docs/src/markdown/demos/3d_models.html
+++ b/docs/src/markdown/demos/3d_models.html
@@ -236,6 +236,7 @@ def create_custom_hsl(gamut):
         NAME = 'hsl-{}'.format(gamut)
         BASE = gamut
         GAMUT_CHECK = gamut
+        CLIP_SPACE = None
         WHITE = cs.WHITE
         DYAMIC_RANGE = cs.DYNAMIC_RANGE
 
@@ -264,6 +265,7 @@ def create_custom_rgb(gamut):
         NAME = '-rgb-{}'.format(gamut)
         BASE = gamut
         GAMUT_CHECK = gamut
+        CLIP_SPACE = None
         WHITE = cs.WHITE
         DYAMIC_RANGE = cs.DYNAMIC_RANGE
         INDEXES = cs.indexes()

--- a/docs/src/markdown/plugins/space.md
+++ b/docs/src/markdown/plugins/space.md
@@ -103,7 +103,7 @@ class XYZD65(Space):
 
     # Some color spaces are a transform of a specific RGB color space gamut, e.g. HSL has a gamut of sRGB.
     # When testing or gamut mapping a color within the current color space's gamut, `GAMUT_CHECK` will
-    # declare which space must be used as reference.
+    # declare which space must be used as reference if anything other than the current space is required.
     #
     # Specifically, when testing if a color is in gamut, both the origin space and the specified gamut
     # space will be checked as sometimes a color is within the threshold of being "close enough" to the gamut,

--- a/docs/src/markdown/plugins/space.md
+++ b/docs/src/markdown/plugins/space.md
@@ -101,16 +101,22 @@ class XYZD65(Space):
     # Some basic ones are provided in the `cat` module for both 2 degree and 10 degree observer.
     WHITE = cat.WHITES['2deg']['D65']
 
-    # If `GAMUT_CHECK` is set to a color space name, the provided color space will be used to verify the an "in gamut"
-    # check in addition to the current color space's channel ranges. This is often used with color spaces such as:
-    # HSL, HSV, and HWB where `GAMUT_CHECK` will be set to `srgb`.
+    # Some color spaces are a transform of a specific RGB color space gamut, e.g. HSL has a gamut of sRGB.
+    # When testing or gamut mapping a color within the current color space's gamut, `GAMUT_CHECK` will
+    # declare which space must be used as reference.
     #
-    # Gamut checking:
-    #   The specified color space will be checked first followed by the original. Assuming the parent color space fits,
-    #   the original should fit as well, but there are some cases when a parent color space that is slightly out of
-    #   gamut, when evaluated with a threshold, may appear to be in gamut enough, but when checking the original color
-    #   space, the values can be greatly out of specification (looking at you HSL).
+    # Specifically, when testing if a color is in gamut, both the origin space and the specified gamut
+    # space will be checked as sometimes a color is within the threshold of being "close enough" to the gamut,
+    # but the color can still be far outside the origin space's coordinates. Checking both ensures sane values
+    # that are also close enough to the gamut.
+    #
+    # When actually gamut mapping, only the gamut space is used, if none is specified, the origin space is used.
     GAMUT_CHECK = None
+
+    # `CLIP_SPACE` forces a different space to be used for clipping than what is specified by `GAMUT_CHECK`.
+    # This is used in cases like HSL where the `GAMUT_CHECK` space is sRGB, but we want to clip in HSL as it
+    # is still reasonable and faster.
+    CLIP_SPACE = None
 
     # What is the color space's dynamic range
     DYNAMIC_RANGE = 'sdr'

--- a/tests/test_cubehelix.py
+++ b/tests/test_cubehelix.py
@@ -51,7 +51,7 @@ class TestCubehelixSerialize(util.ColorAssertsPyTest):
         ('color(--cubehelix 50 0.3 none)', {}, 'color(--cubehelix 50 0.3 0)'),
         ('color(--cubehelix 50 0.3 none)', {'none': True}, 'color(--cubehelix 50 0.3 none)'),
         # Test Fit (not bound)
-        ('color(--cubehelix 50 5 0.5)', {}, 'color(--cubehelix 50.905 4.6144 0.48511)'),
+        ('color(--cubehelix 50 5 0.5)', {}, 'color(--cubehelix 54.82 0.93023 0.45289)'),
         ('color(--cubehelix 50 5 0.5)', {'fit': False}, 'color(--cubehelix 50 5 0.5)')
     ]
 

--- a/tests/test_gamut.py
+++ b/tests/test_gamut.py
@@ -87,6 +87,19 @@ class TestGamut(util.ColorAsserts, unittest.TestCase):
         self.assertColorEqual(color2, Color('rgb(0 255 0)'))
         self.assertTrue(color2.in_gamut('srgb'))
 
+    def test_clip_other_gamut(self):
+        """Test clip when a space defines another space as the gamut."""
+
+        color = Color('orgb', [0.2, 1, 0.8])
+        self.assertColorEqual(color.clip(), Color('color(--orgb 0.28313 0.1328 0.6872)'))
+
+    def test_clip_other_gamut_in_gamut(self):
+        """Test clip when a space defines another space as the gamut but it is in gamut."""
+
+        color = Color('orange').convert('orgb')
+        color2 = color.clone()
+        self.assertColorEqual(color.clip(), color2)
+
     def test_sdr_extremes_low(self):
         """Test SDR extreme low case."""
 

--- a/tests/test_hsi.py
+++ b/tests/test_hsi.py
@@ -51,7 +51,7 @@ class TestHSISerialize(util.ColorAssertsPyTest):
         ('color(--hsi 50 0.3 none)', {}, 'color(--hsi 50 0.3 0)'),
         ('color(--hsi 50 0.3 none)', {'none': True}, 'color(--hsi 50 0.3 none)'),
         # Test Fit (not bound)
-        ('color(--hsi 50 1.1 0.5)', {}, 'color(--hsi 50 1 0.5)'),
+        ('color(--hsi 50 1.1 0.5)', {}, 'color(--hsi 49.412 1 0.51667)'),
         ('color(--hsi 50 1.1 0.5)', {'fit': False}, 'color(--hsi 50 1.1 0.5)')
     ]
 

--- a/tests/test_hsl.py
+++ b/tests/test_hsl.py
@@ -89,7 +89,7 @@ class TestHSLSerialize(util.ColorAssertsPyTest):
         ('hsl(none 30% 75%)', {}, 'hsl(0 30% 75%)'),
         ('hsl(none 30% 75%)', {'none': True}, 'hsl(none 30% 75%)'),
         # Test fit
-        ('hsl(20 150% 75%)', {}, 'hsl(19.619 100% 76.43%)'),
+        ('hsl(20 150% 75%)', {}, 'hsl(21.118 100% 74.445%)'),
         ('hsl(20 150% 75%)', {'fit': False}, 'hsl(20 150% 75%)'),
         # Test legacy
         ('hsl(270 30% 75%)', {'comma': True}, 'hsl(270, 30%, 75%)'),
@@ -109,7 +109,7 @@ class TestHSLSerialize(util.ColorAssertsPyTest):
         ('hsl(0 30% 75%)', {'color': True, 'alpha': True}, 'color(--hsl 0 0.3 0.75 / 1)'),
         ('hsl(0 30% 75% / 0.5)', {'color': True, 'alpha': False}, 'color(--hsl 0 0.3 0.75)'),
         # Test Fit
-        ('color(--hsl 0 -1.1 0.3)', {'color': True}, 'color(--hsl 180 1 0.3028)'),
+        ('color(--hsl 0 -1.1 0.3)', {'color': True}, 'color(--hsl 180 1 0.315)'),
         ('color(--hsl 0 -1.1 0.3)', {'color': True, 'fit': False}, 'color(--hsl 0 -1.1 0.3)'),
         # Test corner cases
         ('hsl(270deg-0.9%.9)', {'color': True, 'fit': False}, 'color(--hsl 270 -0.009 0.009)')

--- a/tests/test_hsluv/test_hsluv.py
+++ b/tests/test_hsluv/test_hsluv.py
@@ -51,7 +51,7 @@ class TestHSLuvSerialize(util.ColorAssertsPyTest):
         ('color(--hsluv 50 30 none)', {}, 'color(--hsluv 50 30 0)'),
         ('color(--hsluv 50 30 none)', {'none': True}, 'color(--hsluv 50 30 none)'),
         # Test Fit (not bound)
-        ('color(--hsluv 50 110 50)', {}, 'color(--hsluv 51.208 100 50)'),
+        ('color(--hsluv 50 110 50)', {}, 'color(--hsluv 50.212 100 50.069)'),
         ('color(--hsluv 50 110 50)', {'fit': False}, 'color(--hsluv 50 110 50)')
     ]
 

--- a/tests/test_hsv.py
+++ b/tests/test_hsv.py
@@ -50,7 +50,7 @@ class TestHSVSerialize(util.ColorAssertsPyTest):
         ('color(--hsv 50 0.3 none)', {}, 'color(--hsv 50 0.3 0)'),
         ('color(--hsv 50 0.3 none)', {'none': True}, 'color(--hsv 50 0.3 none)'),
         # Test Fit (not bound)
-        ('color(--hsv 50 1.1 0.5)', {}, 'color(--hsv 50 1 0.5)'),
+        ('color(--hsv 50 1.1 0.5)', {}, 'color(--hsv 49 1 0.5)'),
         ('color(--hsv 50 1.1 0.5)', {'fit': False}, 'color(--hsv 50 1.1 0.5)')
     ]
 

--- a/tests/test_hwb.py
+++ b/tests/test_hwb.py
@@ -66,7 +66,7 @@ class TestHWBSerialize(util.ColorAssertsPyTest):
         ('hwb(none 30% 50%)', {}, 'hwb(0 30% 50%)'),
         ('hwb(none 30% 50%)', {'none': True}, 'hwb(none 30% 50%)'),
         # Test fit
-        ('hwb(20 0% -55%)', {}, 'hwb(16.837 75.709% 0%)'),
+        ('hwb(20 0% -55%)', {}, 'hwb(18.693 76.677% 0%)'),
         ('hwb(20 0% -55%)', {'fit': False}, 'hwb(20 0% -55%)'),
         # Test color
         ('hwb(none 30% 50% / 0.5)', {'color': True}, 'color(--hwb 0 0.3 0.5 / 0.5)'),

--- a/tests/test_okhsl.py
+++ b/tests/test_okhsl.py
@@ -53,7 +53,7 @@ class TestOkhslSerialize(util.ColorAssertsPyTest):
         ('color(--okhsl 50 0.3 none)', {}, 'color(--okhsl 50 0.3 0)'),
         ('color(--okhsl 50 0.3 none)', {'none': True}, 'color(--okhsl 50 0.3 none)'),
         # Test Fit (not bound)
-        ('color(--okhsl 50 1.1 0.5)', {}, 'color(--okhsl 48.679 1 0.50045)'),
+        ('color(--okhsl 50 1.1 0.5)', {}, 'color(--okhsl 50 1 0.5)'),
         ('color(--okhsl 50 1.1 0.5)', {'fit': False}, 'color(--okhsl 50 1.1 0.5)')
     ]
 

--- a/tests/test_okhsl.py
+++ b/tests/test_okhsl.py
@@ -53,7 +53,7 @@ class TestOkhslSerialize(util.ColorAssertsPyTest):
         ('color(--okhsl 50 0.3 none)', {}, 'color(--okhsl 50 0.3 0)'),
         ('color(--okhsl 50 0.3 none)', {'none': True}, 'color(--okhsl 50 0.3 none)'),
         # Test Fit (not bound)
-        ('color(--okhsl 50 1.1 0.5)', {}, 'color(--okhsl 50 1 0.5)'),
+        ('color(--okhsl 50 1.1 0.5)', {}, 'color(--okhsl 48.679 1 0.50045)'),
         ('color(--okhsl 50 1.1 0.5)', {'fit': False}, 'color(--okhsl 50 1.1 0.5)')
     ]
 

--- a/tests/test_okhsv.py
+++ b/tests/test_okhsv.py
@@ -51,7 +51,7 @@ class TestOkhsvSerialize(util.ColorAssertsPyTest):
         ('color(--okhsv 50 0.3 none)', {}, 'color(--okhsv 50 0.3 0)'),
         ('color(--okhsv 50 0.3 none)', {'none': True}, 'color(--okhsv 50 0.3 none)'),
         # Test Fit (not bound)
-        ('color(--okhsv 50 1.1 0.5)', {}, 'color(--okhsv 50 1 0.5)'),
+        ('color(--okhsv 50 1.1 0.5)', {}, 'color(--okhsv 47.491 1 0.49601)'),
         ('color(--okhsv 50 1.1 0.5)', {'fit': False}, 'color(--okhsv 50 1.1 0.5)')
     ]
 

--- a/tests/test_okhsv.py
+++ b/tests/test_okhsv.py
@@ -51,7 +51,7 @@ class TestOkhsvSerialize(util.ColorAssertsPyTest):
         ('color(--okhsv 50 0.3 none)', {}, 'color(--okhsv 50 0.3 0)'),
         ('color(--okhsv 50 0.3 none)', {'none': True}, 'color(--okhsv 50 0.3 none)'),
         # Test Fit (not bound)
-        ('color(--okhsv 50 1.1 0.5)', {}, 'color(--okhsv 47.491 1 0.49601)'),
+        ('color(--okhsv 50 1.1 0.5)', {}, 'color(--okhsv 50 1 0.5)'),
         ('color(--okhsv 50 1.1 0.5)', {'fit': False}, 'color(--okhsv 50 1.1 0.5)')
     ]
 

--- a/tests/test_orgb.py
+++ b/tests/test_orgb.py
@@ -47,10 +47,10 @@ class TestoRGBSerialize(util.ColorAssertsPyTest):
         ('color(--orgb 0.75 0.1 -0.1)', {'alpha': True}, 'color(--orgb 0.75 0.1 -0.1 / 1)'),
         ('color(--orgb 0.75 0.1 -0.1 / 0.5)', {'alpha': False}, 'color(--orgb 0.75 0.1 -0.1)'),
         # Test None
-        ('color(--orgb none 0.1 -0.1)', {}, 'color(--orgb 0 0.1 -0.1)'),
-        ('color(--orgb none 0.1 -0.1)', {'none': True}, 'color(--orgb none 0.1 -0.1)'),
+        ('color(--orgb 0.67882 0.75654 none)', {}, 'color(--orgb 0.67882 0.75654 0)'),
+        ('color(--orgb 0.67882 0.75654 none)', {'none': True}, 'color(--orgb 0.67882 0.75654 none)'),
         # Test Fit
-        ('color(--orgb 0.75 1.2 -0.1)', {}, 'color(--orgb 0.76398 1 -0.05221)'),
+        ('color(--orgb 0.75 1.2 -0.1)', {}, 'color(--orgb 0.78983 0.88509 -0.04563)'),
         ('color(--orgb 0.75 1.2 -0.1)', {'fit': False}, 'color(--orgb 0.75 1.2 -0.1)')
     ]
 

--- a/tests/test_prismatic.py
+++ b/tests/test_prismatic.py
@@ -50,7 +50,7 @@ class TestPrismaticSerialize(util.ColorAssertsPyTest):
         ('color(--prismatic none 0.3 0.75 0.5)', {}, 'color(--prismatic 0 0.3 0.75 0.5)'),
         ('color(--prismatic none 0.3 0.75 0.5)', {'none': True}, 'color(--prismatic none 0.3 0.75 0.5)'),
         # Test Fit
-        ('color(--prismatic 1.2 0.2 0 0.5)', {}, 'color(--prismatic 1 0.29182 0.11319 0.595)'),
+        ('color(--prismatic 1.2 0.2 0 0.5)', {}, 'color(--prismatic 1 0.30074 0.10948 0.58978)'),
         ('color(--prismatic 1.2 0.2 0 0.5)', {'fit': False}, 'color(--prismatic 1.2 0.2 0 0.5)')
     ]
 

--- a/tools/calc_oklab_matrices.py
+++ b/tools/calc_oklab_matrices.py
@@ -172,25 +172,18 @@ LMS_TO_SRGBL = alg.inv(SRGBL_TO_LMS)
 # ]
 # ```
 # But since the matrix is provided in 32 bit, we are not able to get the
-# inverse, and in return, we do not get a good resolution to `[1, 0, 0]`
-# for white. In order to adjust for this, take documented 32 bit inverse
-# matrix # that expects `[1, 0, 0]` and work backwards to calculate the 64
-# bit version. Make sure to process the value as 32 bit but emit it as 64
-# bit, then correct the 64 bit matrix to ensure it still aligns for `[1, 0, 0]`.
-OKLAB_TO_LMS3 = float32(
-    [
-        [1.0, 0.3963377774, 0.2158037573],
-        [1.0, -0.1055613458, -0.0638541728],
-        [1.0, -0.0894841775, -1.2914855480]
-    ]
-)
-
-# Calculate what we expect the ideal translation for D65 white to be.
-correct = alg.diag([alg.nth_root(c, 3) for c in alg.matmul(XYZ_TO_LMS, xyzt.white_d65)])
-
-# Adjust to target a precise translation for white
-lms3 = alg.diag(alg.matmul(OKLAB_TO_LMS3, [1.0, 0.0, 0.0]))
-OKLAB_TO_LMS3 = alg.matmul(OKLAB_TO_LMS3, alg.matmul(lms3, alg.inv(correct)))
+# proper inverse for `[1, 0, 0]` in 64 bit, even if we calculate the a
+# new 64 bit inverse for the above forward transform. What we need is a
+# proper 64 bit forward and reverse transform.
+#
+# In order to adjust for this, we take documented 32 bit inverse matrix which
+# gives us a perfect translation from Oklab `[1, 0, 0]` to LMS of `[1, 1, 1]`
+# and parse the matrix as float 32 and emit it as 64 bit and then take the inverse.
+OKLAB_TO_LMS3 = [
+    [1.0, 0.3963377774, 0.2158037573],
+    [1.0, -0.1055613458, -0.0638541728],
+    [1.0, -0.0894841775, -1.2914855480]
+]
 
 # Calculate the inverse
 LMS3_TO_OKLAB = alg.inv(OKLAB_TO_LMS3)

--- a/tools/calc_oklab_matrices.py
+++ b/tools/calc_oklab_matrices.py
@@ -24,12 +24,10 @@ achromatic colors in Oklab and OkLCh and can cause chroma not to resolve to zero
 To provide an M2 matrix that works better for 64 bit, we take the inverse M2,
 which provides a perfect transforms to white from Oklab `[1, 0, 0]` in 32 bit
 floating point. We process the matrix as float 32 bit values and emit them as 64
-bit double values, ~17 digit double accuracy. Then we apply a slight correction
-to account for the 64 bit noise to ensure it converts a perfect Oklab `[1, 0, 0]`
-to LMS `[1, 1, 1]`. Once corrected, we then calculate the forward matrix. This
-gives us a transform in 64 bit that drives chroma extremely close to zero for
-64 bit doubles and maintains the same 32 bit precision of up to about 7 digits,
-the 32 bit accuracy limit (~7.22).
+bit double values, ~17 digit double accuracy. We then calculate the forward
+matrix. This gives us a transform in 64 bit that drives chroma extremely close
+to zero for 64 bit doubles and maintains the same 32 bit precision of up to about
+7 digits, the 32 bit accuracy limit (~7.22).
 
 To demonstrate that our 64 bit converted matrices work as we claim and does not
 alter the intent of the values, we can observe by comparing the documented matrices
@@ -179,11 +177,11 @@ LMS_TO_SRGBL = alg.inv(SRGBL_TO_LMS)
 # In order to adjust for this, we take documented 32 bit inverse matrix which
 # gives us a perfect translation from Oklab `[1, 0, 0]` to LMS of `[1, 1, 1]`
 # and parse the matrix as float 32 and emit it as 64 bit and then take the inverse.
-OKLAB_TO_LMS3 = [
+OKLAB_TO_LMS3 = float32([
     [1.0, 0.3963377774, 0.2158037573],
     [1.0, -0.1055613458, -0.0638541728],
     [1.0, -0.0894841775, -1.2914855480]
-]
+])
 
 # Calculate the inverse
 LMS3_TO_OKLAB = alg.inv(OKLAB_TO_LMS3)

--- a/tools/gamut_3d_diagrams.py
+++ b/tools/gamut_3d_diagrams.py
@@ -39,6 +39,7 @@ def create_custom_hsl(gamut):
         NAME = '-hsl-{}'.format(gamut)
         BASE = gamut
         GAMUT_CHECK = gamut
+        CLIP_SPACE = None
         WHITE = cs.WHITE
         DYAMIC_RANGE = cs.DYNAMIC_RANGE
 

--- a/tools/gamut_3d_plotly.py
+++ b/tools/gamut_3d_plotly.py
@@ -31,6 +31,7 @@ def create_custom_hsl(gamut):
         NAME = '-hsl-{}'.format(gamut)
         BASE = gamut
         GAMUT_CHECK = gamut
+        CLIP_SPACE = None
         WHITE = cs.WHITE
         DYAMIC_RANGE = cs.DYNAMIC_RANGE
 
@@ -59,6 +60,7 @@ def create_custom_rgb(gamut):
         NAME = '-rgb-{}'.format(gamut)
         BASE = gamut
         GAMUT_CHECK = gamut
+        CLIP_SPACE = None
         WHITE = cs.WHITE
         DYAMIC_RANGE = cs.DYNAMIC_RANGE
         INDEXES = cs.indexes()

--- a/tools/oklab_srgb_gamut_approximation.py
+++ b/tools/oklab_srgb_gamut_approximation.py
@@ -71,9 +71,9 @@ OKLAB_TO_LMS3 = np.asfarray(OKLAB_TO_LMS3)
 
 
 def linear_srgb_to_oklab(c):
-    l = RGBL_TO_LMS[0][0] * c[0,...] + RGBL_TO_LMS[0][1] * c[1,...] + RGBL_TO_LMS[0][2] * c[2,...]
-    m = RGBL_TO_LMS[1][0] * c[0,...] + RGBL_TO_LMS[1][1] * c[1,...] + RGBL_TO_LMS[1][2] * c[2,...]
-    s = RGBL_TO_LMS[2][0] * c[0,...] + RGBL_TO_LMS[2][1] * c[1,...] + RGBL_TO_LMS[2][2] * c[2,...]
+    l = RGBL_TO_LMS[0][0] * c[0, ...] + RGBL_TO_LMS[0][1] * c[1, ...] + RGBL_TO_LMS[0][2] * c[2, ...]
+    m = RGBL_TO_LMS[1][0] * c[0, ...] + RGBL_TO_LMS[1][1] * c[1, ...] + RGBL_TO_LMS[1][2] * c[2, ...]
+    s = RGBL_TO_LMS[2][0] * c[0, ...] + RGBL_TO_LMS[2][1] * c[1, ...] + RGBL_TO_LMS[2][2] * c[2, ...]
 
     l_ = np.cbrt(l)
     m_ = np.cbrt(m)
@@ -85,88 +85,88 @@ def linear_srgb_to_oklab(c):
         LMS3_TO_OKLAB[2][0] * l_ + LMS3_TO_OKLAB[2][1] * m_ + LMS3_TO_OKLAB[2][2] * s_,
     ])
 
-# define functions for R, G and B as functions of S,h (with L = 1 and S = C/L)
+# define functions for R, G and B as functions of S, h (with L = 1 and S = C/L)
 
-def to_lms(S,h):
-  a = S*np.cos(h)
-  b = S*np.sin(h)
-
-  l_ = OKLAB_TO_LMS3[0][0] + OKLAB_TO_LMS3[0][1] * a + OKLAB_TO_LMS3[0][2] * b
-  m_ = OKLAB_TO_LMS3[1][0] + OKLAB_TO_LMS3[1][1] * a + OKLAB_TO_LMS3[1][2] * b
-  s_ = OKLAB_TO_LMS3[2][0] + OKLAB_TO_LMS3[2][1] * a + OKLAB_TO_LMS3[2][2] * b
-
-  l = l_*l_*l_
-  m = m_*m_*m_
-  s = s_*s_*s_
-
-  return (l,m,s)
-
-def to_lms_dS(S,h):
-  a = S*np.cos(h)
-  b = S*np.sin(h)
+def to_lms(S, h):
+  a = S * np.cos(h)
+  b = S * np.sin(h)
 
   l_ = OKLAB_TO_LMS3[0][0] + OKLAB_TO_LMS3[0][1] * a + OKLAB_TO_LMS3[0][2] * b
   m_ = OKLAB_TO_LMS3[1][0] + OKLAB_TO_LMS3[1][1] * a + OKLAB_TO_LMS3[1][2] * b
   s_ = OKLAB_TO_LMS3[2][0] + OKLAB_TO_LMS3[2][1] * a + OKLAB_TO_LMS3[2][2] * b
 
-  l = (LMS3_TO_OKLAB[0][1]*np.cos(h) + LMS3_TO_OKLAB[0][1]*np.sin(h))*3*l_*l_
-  m = (LMS3_TO_OKLAB[1][1]*np.cos(h) + LMS3_TO_OKLAB[1][1]*np.sin(h))*3*m_*m_
-  s = (LMS3_TO_OKLAB[2][1]*np.cos(h) + LMS3_TO_OKLAB[2][1]*np.sin(h))*3*s_*s_
+  l = l_ * l_ * l_
+  m = m_ * m_ * m_
+  s = s_ * s_ * s_
 
-  return (l,m,s)
+  return (l, m, s)
 
-def to_lms_dS2(S,h):
-  a = S*np.cos(h)
-  b = S*np.sin(h)
+def to_lms_dS(S, h):
+  a = S * np.cos(h)
+  b = S * np.sin(h)
 
   l_ = OKLAB_TO_LMS3[0][0] + OKLAB_TO_LMS3[0][1] * a + OKLAB_TO_LMS3[0][2] * b
   m_ = OKLAB_TO_LMS3[1][0] + OKLAB_TO_LMS3[1][1] * a + OKLAB_TO_LMS3[1][2] * b
   s_ = OKLAB_TO_LMS3[2][0] + OKLAB_TO_LMS3[2][1] * a + OKLAB_TO_LMS3[2][2] * b
 
-  l = (LMS3_TO_OKLAB[0][1]*np.cos(h) + LMS3_TO_OKLAB[0][2]*np.sin(h))**2*6*l_
-  m = (LMS3_TO_OKLAB[1][1]*np.cos(h) + LMS3_TO_OKLAB[0][2]*np.sin(h))**2*6*m_
-  s = (LMS3_TO_OKLAB[2][1]*np.cos(h) + LMS3_TO_OKLAB[0][2]*np.sin(h))**2*6*s_
+  l = (LMS3_TO_OKLAB[0][1] * np.cos(h) + LMS3_TO_OKLAB[0][1] * np.sin(h)) * 3 * l_* l_
+  m = (LMS3_TO_OKLAB[1][1] * np.cos(h) + LMS3_TO_OKLAB[1][1] * np.sin(h)) * 3 * m_* m_
+  s = (LMS3_TO_OKLAB[2][1] * np.cos(h) + LMS3_TO_OKLAB[2][1] * np.sin(h)) * 3 * s_* s_
 
-  return (l,m,s)
+  return (l, m, s)
+
+def to_lms_dS2(S, h):
+  a = S * np.cos(h)
+  b = S * np.sin(h)
+
+  l_ = OKLAB_TO_LMS3[0][0] + OKLAB_TO_LMS3[0][1] * a + OKLAB_TO_LMS3[0][2] * b
+  m_ = OKLAB_TO_LMS3[1][0] + OKLAB_TO_LMS3[1][1] * a + OKLAB_TO_LMS3[1][2] * b
+  s_ = OKLAB_TO_LMS3[2][0] + OKLAB_TO_LMS3[2][1] * a + OKLAB_TO_LMS3[2][2] * b
+
+  l = (LMS3_TO_OKLAB[0][1] * np.cos(h) + LMS3_TO_OKLAB[0][2] * np.sin(h)) ** 2 * 6 * l_
+  m = (LMS3_TO_OKLAB[1][1] * np.cos(h) + LMS3_TO_OKLAB[0][2] * np.sin(h)) ** 2 * 6 * m_
+  s = (LMS3_TO_OKLAB[2][1] * np.cos(h) + LMS3_TO_OKLAB[0][2] * np.sin(h)) ** 2 * 6 * s_
+
+  return (l, m, s)
 
 
-def to_R(S,h):
-  (l,m,s) = to_lms(S,h)
-  return LMS_TO_RGBL[0][0]*l + LMS_TO_RGBL[0][1]*m + LMS_TO_RGBL[0][2]*s
+def to_R(S, h):
+  (l, m, s) = to_lms(S, h)
+  return LMS_TO_RGBL[0][0] * l + LMS_TO_RGBL[0][1] * m + LMS_TO_RGBL[0][2] * s
 
-def to_R_dS(S,h):
-  (l,m,s) = to_lms_dS(S,h)
-  return LMS_TO_RGBL[0][0]*l + LMS_TO_RGBL[0][1]*m + LMS_TO_RGBL[0][2]*s
+def to_R_dS(S, h):
+  (l, m, s) = to_lms_dS(S, h)
+  return LMS_TO_RGBL[0][0] * l + LMS_TO_RGBL[0][1] * m + LMS_TO_RGBL[0][2] * s
 
-def to_R_dS2(S,h):
-  (l,m,s) = to_lms_dS2(S,h)
-  return LMS_TO_RGBL[0][0]*l + LMS_TO_RGBL[0][1]*m + LMS_TO_RGBL[0][2]*s
+def to_R_dS2(S, h):
+  (l, m, s) = to_lms_dS2(S, h)
+  return LMS_TO_RGBL[0][0] * l + LMS_TO_RGBL[0][1] * m + LMS_TO_RGBL[0][2] * s
 
-def to_G(S,h):
-  (l,m,s) = to_lms(S,h)
-  return LMS_TO_RGBL[1][0]*l + LMS_TO_RGBL[1][1]*m + LMS_TO_RGBL[1][2]*s
+def to_G(S, h):
+  (l, m, s) = to_lms(S, h)
+  return LMS_TO_RGBL[1][0] * l + LMS_TO_RGBL[1][1] * m + LMS_TO_RGBL[1][2] * s
 
-def to_G_dS(S,h):
-  (l,m,s) = to_lms_dS(S,h)
-  return LMS_TO_RGBL[1][0]*l + LMS_TO_RGBL[1][1]*m + LMS_TO_RGBL[1][2]*s
+def to_G_dS(S, h):
+  (l, m, s) = to_lms_dS(S, h)
+  return LMS_TO_RGBL[1][0] * l + LMS_TO_RGBL[1][1] * m + LMS_TO_RGBL[1][2] * s
 
-def to_G_dS2(S,h):
-  (l,m,s) = to_lms_dS2(S,h)
-  return LMS_TO_RGBL[1][0]*l + LMS_TO_RGBL[1][1]*m + LMS_TO_RGBL[1][2]*s
+def to_G_dS2(S, h):
+  (l, m, s) = to_lms_dS2(S, h)
+  return LMS_TO_RGBL[1][0] * l + LMS_TO_RGBL[1][1] * m + LMS_TO_RGBL[1][2] * s
 
-def to_B(S,h):
-  (l,m,s) = to_lms(S,h)
-  return LMS_TO_RGBL[2][0]*l + LMS_TO_RGBL[2][1]*m + LMS_TO_RGBL[2][2]*s
+def to_B(S, h):
+  (l, m, s) = to_lms(S, h)
+  return LMS_TO_RGBL[2][0] * l + LMS_TO_RGBL[2][1] * m + LMS_TO_RGBL[2][2] * s
 
-def to_B_dS(S,h):
-  (l,m,s) = to_lms_dS(S,h)
-  return LMS_TO_RGBL[2][0]*l + LMS_TO_RGBL[2][1]*m + LMS_TO_RGBL[2][2]*s
+def to_B_dS(S, h):
+  (l, m, s) = to_lms_dS(S, h)
+  return LMS_TO_RGBL[2][0] * l + LMS_TO_RGBL[2][1] * m + LMS_TO_RGBL[2][2] * s
 
-def to_B_dS2(S,h):
-  (l,m,s) = to_lms_dS2(S,h)
-  return LMS_TO_RGBL[2][0]*l + LMS_TO_RGBL[2][1]*m + LMS_TO_RGBL[2][2]*s
+def to_B_dS2(S, h):
+  (l, m, s) = to_lms_dS2(S, h)
+  return LMS_TO_RGBL[2][0] * l + LMS_TO_RGBL[2][1] * m + LMS_TO_RGBL[2][2] * s
 
-hs,Ss = np.meshgrid(np.linspace(-np.pi,np.pi,720),np.linspace(0,1,200))
+hs, Ss = np.meshgrid(np.linspace(-np.pi, np.pi, 720), np.linspace(0, 1, 200))
 
 Rs = to_R(Ss, hs)
 Gs = to_G(Ss, hs)
@@ -179,9 +179,9 @@ if PRINT_DIAGS:
     plt.show()
     plt.figure()
 
-r_lab = linear_srgb_to_oklab(np.array([1,0,0]))
-g_lab = linear_srgb_to_oklab(np.array([0,1,0]))
-b_lab = linear_srgb_to_oklab(np.array([0,0,1]))
+r_lab = linear_srgb_to_oklab(np.array([1, 0, 0]))
+g_lab = linear_srgb_to_oklab(np.array([0, 1, 0]))
+b_lab = linear_srgb_to_oklab(np.array([0, 0, 1]))
 
 r_h = np.arctan2(r_lab[2], r_lab[1])
 g_h = np.arctan2(g_lab[2], g_lab[1])
@@ -191,13 +191,13 @@ print(r_h)
 print(g_h)
 print(b_h)
 
-r_dir = 0.5*np.array([np.cos(b_h)+np.cos(g_h),np.sin(b_h)+np.sin(g_h)])
-g_dir = 0.5*np.array([np.cos(b_h)+np.cos(r_h),np.sin(b_h)+np.sin(r_h)])
-b_dir = 0.5*np.array([np.cos(r_h)+np.cos(g_h),np.sin(r_h)+np.sin(g_h)])
+r_dir = 0.5 * np.array([np.cos(b_h) + np.cos(g_h), np.sin(b_h) + np.sin(g_h)])
+g_dir = 0.5 * np.array([np.cos(b_h) + np.cos(r_h), np.sin(b_h) + np.sin(r_h)])
+b_dir = 0.5 * np.array([np.cos(r_h) + np.cos(g_h), np.sin(r_h) + np.sin(g_h)])
 
-r_dir /= r_dir[0]**2 + r_dir[1]**2
-g_dir /= g_dir[0]**2 + g_dir[1]**2
-b_dir /= b_dir[0]**2 + b_dir[1]**2
+r_dir /= r_dir[0]** 2 + r_dir[1]** 2
+g_dir /= g_dir[0]** 2 + g_dir[1]** 2
+b_dir /= b_dir[0]** 2 + b_dir[1]** 2
 
 # These are coefficients to quickly test which component goes below zero first.
 # Used like this in compute_max_saturation:
@@ -207,7 +207,7 @@ print(r_dir)
 print(g_dir)
 print(b_dir)
 
-r_hs,r_Ss = np.meshgrid(np.linspace(g_h,2*np.pi + b_h,200),np.linspace(0,1,200))
+r_hs, r_Ss = np.meshgrid(np.linspace(g_h, 2 * np.pi + b_h, 200), np.linspace(0, 1, 200))
 
 r_Rs = to_R(r_Ss, r_hs)
 
@@ -216,7 +216,7 @@ if PRINT_DIAGS:
     plt.show()
     plt.figure()
 
-g_hs,g_Ss = np.meshgrid(np.linspace(b_h,r_h,200),np.linspace(0,1,200))
+g_hs, g_Ss = np.meshgrid(np.linspace(b_h, r_h, 200), np.linspace(0, 1, 200))
 
 g_Gs = to_G(g_Ss, g_hs)
 
@@ -225,7 +225,7 @@ if PRINT_DIAGS:
     plt.show()
     plt.figure()
 
-b_hs,b_Ss = np.meshgrid(np.linspace(r_h,g_h,200),np.linspace(0,1,200))
+b_hs, b_Ss = np.meshgrid(np.linspace(r_h, g_h, 200), np.linspace(0, 1, 200))
 
 b_Bs = to_B(b_Ss, b_hs)
 
@@ -239,28 +239,30 @@ if PRINT_DIAGS:
 
 its = 1
 
-h = np.linspace(g_h,2*np.pi + b_h,1000)
+resolution = 100000
+
+h = np.linspace(g_h, 2 * np.pi + b_h, resolution)
 a = np.cos(h)
 b = np.sin(h)
 
 def e_R(x):
-  S = x[0] + x[1]*a + x[2]*b + x[3]*a**2 + x[4]*a*b
+  S = x[0] + x[1] * a + x[2] * b + x[3] * a ** 2 + x[4] * a * b
   S = np.maximum(0, S)
 
   # optimize for solution that is easiest to solve with one step Haley's method
   f = to_R(S, h)
   f1 = to_R_dS(S, h)
   f2 = to_R_dS2(S, h)
-  S_1 = S - f*f1/(f1**2 - f*f2/2)
+  S_1 = S - f * f1 / (f1 ** 2 - f * f2 / 2)
 
   f_ = to_R(S_1, h)
-  return np.average(f_**10) #+ f_[0]**2 + f_[-1]**2
+  return np.average(f_ ** 10) # + f_[0] ** 2 + f_[-1] ** 2
 
 x_R = scipy.optimize.minimize(e_R, np.array([1.19086277, 1.76576728, 0.59662641, 0.75515197, 0.56771245])).x
 
 print(x_R)
 
-S_R = x_R[0] + x_R[1]*a + x_R[2]*b + x_R[3]*a**2 + x_R[4]*a*b
+S_R = x_R[0] + x_R[1] * a + x_R[2] * b + x_R[3] * a ** 2 + x_R[4] * a * b
 
 plt.plot(S_R, 'r')
 plt.figure()
@@ -269,11 +271,11 @@ plt.plot(to_R(S_R, h), 'r')
 plt.figure()
 
 S_R1 = S_R
-for i in range(0,its):
+for i in range(0, its):
   f = to_R(S_R1, h)
   f1 = to_R_dS(S_R1, h)
   f2 = to_R_dS2(S_R1, h)
-  S_R1 = S_R1 - f*f1/(f1**2 - f*f2/(2))
+  S_R1 = S_R1 - f * f1 / (f1 ** 2 - f * f2 / (2))
 
   plt.plot(S_R1, 'r')
 
@@ -284,28 +286,28 @@ plt.figure()
 
 #####
 
-h = np.linspace(b_h,r_h,1000)
+h = np.linspace(b_h, r_h, resolution)
 a = np.cos(h)
 b = np.sin(h)
 
 def e_G(x):
-  S = x[0] + x[1]*a + x[2]*b + x[3]*a**2 + x[4]*a*b
+  S = x[0] + x[1] * a + x[2] * b + x[3] * a ** 2 + x[4] * a * b
   S = np.maximum(0, S)
 
   # optimize for solution that is easiest to solve with one step Haley's method
   f = to_G(S, h)
   f1 = to_G_dS(S, h)
   f2 = to_G_dS2(S, h)
-  S_1 = S - f*f1/(f1**2 - f*f2/2)
+  S_1 = S - f * f1 / (f1 ** 2 - f * f2 / 2)
 
   f_ = to_G(S_1, h)
-  return np.average(f_**10) #+ f_[0]**2 + f_[-1]**2
+  return np.average(f_ ** 10) # + f_[0] ** 2 + f_[-1] ** 2
 
 x_G = scipy.optimize.minimize(e_G, np.array([0.73956515, -0.45954404,  0.08285427,  0.12541073, -0.14503204])).x
 
 print(x_G)
 
-S_G = x_G[0] + x_G[1]*a + x_G[2]*b + x_G[3]*a**2 + x_G[4]*a*b
+S_G = x_G[0] + x_G[1] * a + x_G[2] * b + x_G[3] * a ** 2 + x_G[4] * a * b
 
 plt.plot(S_G, 'g')
 plt.figure()
@@ -314,11 +316,11 @@ plt.plot(to_G(S_G, h), 'g')
 plt.figure()
 
 S_G1 = S_G
-for i in range(0,its):
+for i in range(0, its):
   f = to_G(S_G1, h)
   f1 = to_G_dS(S_G1, h)
   f2 = to_G_dS2(S_G1, h)
-  S_G1 = S_G1 - f*f1/(f1**2 - f*f2/(2))
+  S_G1 = S_G1 - f * f1 / (f1 ** 2 - f * f2 / (2))
 
   plt.plot(S_G1, 'g')
 
@@ -330,28 +332,28 @@ plt.figure()
 
 #####
 
-h = np.linspace(r_h,g_h,1000)
+h = np.linspace(r_h, g_h, resolution)
 a = np.cos(h)
 b = np.sin(h)
 
 def e_B(x):
-  S = x[0] + x[1]*a + x[2]*b + x[3]*a**2 + x[4]*a*b
+  S = x[0] + x[1] * a + x[2] * b + x[3] * a ** 2 + x[4] * a * b
   S = np.maximum(0, S)
 
   # optimize for solution that is easiest to solve with one step Haley's method
   f = to_B(S, h)
   f1 = to_B_dS(S, h)
   f2 = to_B_dS2(S, h)
-  S_1 = S - f*f1/(f1**2 - f*f2/2)
+  S_1 = S - f * f1 / (f1 ** 2 - f * f2 / 2)
 
   f_ = to_B(S_1, h)
-  return np.average(f_**10) #+ f_[0]**2 + f_[-1]**2
+  return np.average(f_ ** 10) # + f_[0] ** 2 + f_[-1] ** 2
 
 x_B = scipy.optimize.minimize(e_B, np.array([1.35733652, -0.00915799, -1.1513021,  -0.50559606,  0.00692167])).x
 
 print(x_B)
 
-S_B = x_B[0] + x_B[1]*a + x_B[2]*b + x_B[3]*a**2 + x_B[4]*a*b
+S_B = x_B[0] + x_B[1] * a + x_B[2] * b + x_B[3] * a ** 2 + x_B[4] * a * b
 
 plt.plot(S_B, 'b')
 plt.figure()
@@ -360,11 +362,11 @@ plt.plot(to_B(S_B, h), 'b')
 plt.figure()
 
 S_B1 = S_B
-for i in range(0,its):
+for i in range(0, its):
   f = to_B(S_B1, h)
   f1 = to_B_dS(S_B1, h)
   f2 = to_B_dS2(S_B1, h)
-  S_B1 = S_B1 - f*f1/(f1**2 - f*f2/(2))
+  S_B1 = S_B1 - f * f1 / (f1 ** 2 - f * f2 / (2))
 
   plt.plot(S_B1, 'b')
 


### PR DESCRIPTION
1. When gamut mapping, the color space attribute GAMUT_CHECK should be used not only to check whether a color is in gamut, but it should be used as the color reference color space when gamut mapping.
2. When clipping, there are some cases where we can get away with clipping a color in the origin color space even when GAMUT_CHECK specifies a different color space. This saves us time and improves performance. It also allows us to keep compatibility with CSS. To enforce a clipping color space, a space can now set the color space attribute `CLIP_SPACE` to a specific space.