### PR TITLE
Better handling of numerical values in get/set

### DIFF
--- a/coloraide/color.py
+++ b/coloraide/color.py
@@ -959,7 +959,7 @@ class Color(metaclass=ColorMeta):
         """Mask color channels."""
 
         this = self if in_place else self.clone()
-        aliases = self._space.aliases
+        aliases = self._space.CHANNEL_ALIASES
         masks = set(
             [aliases.get(channel, channel)] if isinstance(channel, str) else [aliases.get(c, c) for c in channel]
         )

--- a/coloraide/interpolate/__init__.py
+++ b/coloraide/interpolate/__init__.py
@@ -744,7 +744,7 @@ def interpolator(
         stops,
         space,
         out_space,
-        process_mapping(progress, current._space.aliases),
+        process_mapping(progress, current._space.CHANNEL_ALIASES),
         premultiplied,
         extrapolate,
         domain,

--- a/coloraide/spaces/__init__.py
+++ b/coloraide/spaces/__init__.py
@@ -195,15 +195,15 @@ class Space(Plugin, metaclass=SpaceMeta):
         """Initialize."""
 
         self.channels = self.CHANNELS + (alpha_channel,)
+        self._chan_index = {c: e for e, c in enumerate(self.channels)}
         self._color_ids = (self.NAME,) if not self.SERIALIZE else self.SERIALIZE
         self._percents = ([True] * (len(self.channels) - 1)) + [False]
-        self.aliases = {str(e): str(c) for e, c in enumerate(self.channels)}
-        self.aliases.update(self.CHANNEL_ALIASES)
 
     def get_channel_index(self, name: str) -> int:
         """Get channel index."""
 
-        return self.channels.index(self.aliases.get(name, name))
+        idx = self._chan_index.get(self.CHANNEL_ALIASES.get(name, name))
+        return int(name) if idx is None else idx
 
     def resolve_channel(self, index: int, coords: Vector) -> float:
         """Resolve channels."""

--- a/coloraide/spaces/__init__.py
+++ b/coloraide/spaces/__init__.py
@@ -195,7 +195,7 @@ class Space(Plugin, metaclass=SpaceMeta):
         """Initialize."""
 
         self.channels = self.CHANNELS + (alpha_channel,)
-        self._chan_index = {c: e for e, c in enumerate(self.channels)}
+        self._chan_index = {c: e for e, c in enumerate(self.channels)}  # type: dict[str, int]
         self._color_ids = (self.NAME,) if not self.SERIALIZE else self.SERIALIZE
         self._percents = ([True] * (len(self.channels) - 1)) + [False]
 

--- a/tools/interp_diagram.py
+++ b/tools/interp_diagram.py
@@ -93,9 +93,9 @@ def main():
     c1 = colors[0]
     name1 = args.xaxis.split(":", 1)[0]
     name2 = args.yaxis.split(":", 1)[0]
-    name1 = c1._space.aliases.get(name1, name1)
+    name1 = c1._space.CHANNEL_ALIASES.get(name1, name1)
     index1 = c1._space.get_channel_index(name1)
-    name2 = c1._space.aliases.get(name2, name2)
+    name2 = c1._space.CHANNEL_ALIASES.get(name2, name2)
     hue_index = -1
 
     if isinstance(c1._space, Cylindrical):

--- a/tools/slice_diagram.py
+++ b/tools/slice_diagram.py
@@ -76,7 +76,7 @@ def plot_slice(
         n, v = [
             c if i == 0 else float(c if c != 'none' else 'nan') for i, c in enumerate(chan.split(':'), 0)
         ]
-        n = c._space.aliases.get(n, n)
+        n = c._space.CHANNEL_ALIASES.get(n, n)
         i = c._space.get_channel_index(n)
         chan_constants.append((n, v, i))
 
@@ -89,9 +89,9 @@ def plot_slice(
     ]
 
     # Get the actual indexes of the specified channels
-    name1 = c._space.aliases.get(name1, name1)
+    name1 = c._space.CHANNEL_ALIASES.get(name1, name1)
     index1 = c._space.get_channel_index(name1)
-    name2 = c._space.aliases.get(name2, name2)
+    name2 = c._space.CHANNEL_ALIASES.get(name2, name2)
     index2 = c._space.get_channel_index(name2)
     hue_index = -1
 


### PR DESCRIPTION
Allow negative indexes to work in get/set.

Abandon treating numerical values as aliases. Instead, utilize a mapping of channel name to index.