### PR TITLE
Ensure spline based interpolation is truly discrete when using discrete

### DIFF
--- a/coloraide/color.py
+++ b/coloraide/color.py
@@ -1035,7 +1035,7 @@ class Color(metaclass=ColorMeta):
         num = sum((not callable(c) or not isinstance(c, interpolate.stop)) for c in colors) if steps is None else steps
         i = cls.interpolate(colors, space=space, **interpolate_args)
         # Convert the interpolation into a discretized interpolation with the requested number of steps
-        i.discretize(num, max_steps, max_delta_e, delta_e, delta_e_args)
+        i = i.discretize(num, max_steps, max_delta_e, delta_e, delta_e_args)
         if domain is not None:
             i.domain(domain)
         if out_space is not None:

--- a/coloraide/interpolate/__init__.py
+++ b/coloraide/interpolate/__init__.py
@@ -127,8 +127,10 @@ class Interpolator(metaclass=ABCMeta):
         max_delta_e: float = 0,
         delta_e: str | None = None,
         delta_e_args: dict[str, Any] | None = None,
-    ) -> None:
+    ) -> Interpolator:
         """Make the interpolation a discretized interpolation."""
+
+        from .linear import Linear
 
         # Get the discrete steps for the new discrete interpolation
         colors = self.steps(steps, max_steps, max_delta_e, delta_e, delta_e_args)
@@ -149,21 +151,21 @@ class Interpolator(metaclass=ABCMeta):
             coords.extend([step1, step2])
             count += 2
 
-        # Update colors and stops
-        self.coordinates = coords
-        self.length = len(self.coordinates)
-        self.stops = stops
-        self.start = self.stops[0]
-        self.end = self.stops[len(self.stops) - 1]
-
-        # Reset features that were used to generate the discrete steps
-        self.easings = [None] * (self.length - 1)
-        self.progress = None
-        self.current_easing = None
-        self._padding = None
-        self._domain = []
-
-        self.setup()
+        return Linear().interpolator(
+            coordinates=coords,
+            channel_names=self.channel_names,
+            create=self.create,
+            easings=[None] * (len(coords) - 1),
+            stops=stops,
+            space=self.space,
+            out_space=self._out_space,
+            progress=self.progress,
+            premultiplied=self.premultiplied,
+            extrapolate=self.extrapolate,
+            domain=[],
+            padding=None,
+            hue = self.hue
+        )
 
     def out_space(self, space: str) -> None:
         """Set output space."""

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -8,6 +8,7 @@
     support will be removed for these spaces. Additionally, these spaces are now registered by default.
 -   **NEW**: ∆E methods `z` and `itp` are now registered by default as their associated color spaces are now registered
     by default as well.
+-   **FIX**: Ensure that when using discrete interpolation that spline based interpolations are truly discrete.
 
 ## 2.16
 


### PR DESCRIPTION
Because we were "discretizing" interpolations in place, spline-based interpolators were still affecting the edges of discrete blocks as these interpolators take into account more than two colors. After generating the discrete steps, package it up into a linear interpolator and return that.