### PR TITLE
Make using different CAM16 UCS spaces for ∆Ecam16 possible

### DIFF
--- a/coloraide/distance/delta_e_cam16.py
+++ b/coloraide/distance/delta_e_cam16.py
@@ -45,7 +45,7 @@ class DECAM16(DeltaE):
             cs = color.CS_MAP[space]
             if not isinstance(color.CS_MAP[space], CAM16UCS):
                 raise ValueError("Distance color space must be derived from CAM16UCS.")
-            model = cs.MODEL
+            model = cs.MODEL  # type: ignore[attr-defined]
             kl = COEFFICENTS[model][0]
 
         j1, a1, b1 = color.convert(space).coords(nans=False)

--- a/coloraide/distance/delta_e_cam16.py
+++ b/coloraide/distance/delta_e_cam16.py
@@ -6,11 +6,17 @@ https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9698626/pdf/sensors-22-08869.pdf
 from __future__ import annotations
 import math
 from ..distance import DeltaE
+from ..deprecate import warn_deprecated
 from typing import Any, TYPE_CHECKING
-from ..spaces.cam16_ucs import COEFFICENTS
+from ..spaces.cam16_ucs import COEFFICENTS, CAM16UCS
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..color import Color
+
+
+WARN_MSG = (
+    "The 'model' parameter is now deprecated, please specify the CAM16 UCS/LCD/SCD space name via 'space' instead"
+)
 
 
 class DECAM16(DeltaE):
@@ -18,11 +24,30 @@ class DECAM16(DeltaE):
 
     NAME = "cam16"
 
-    def distance(self, color: Color, sample: Color, model: str = 'ucs', **kwargs: Any) -> float:
-        """Delta E z color distance formula."""
+    def distance(
+        self,
+        color: Color,
+        sample: Color,
+        space: str = "cam16-ucs",
+        model: str | None = None,
+        **kwargs: Any
+    ) -> float:
+        """Delta E CAM16 color distance formula."""
 
-        space = 'cam16-{}'.format(model)
-        kl = COEFFICENTS[model][0]
+        # Legacy approach to specifying CAM16 approach
+        if model is not None:  # pragma: no cover
+            warn_deprecated(WARN_MSG)
+            space = 'cam16-{}'.format(model)
+            kl = COEFFICENTS[model][0]
+
+        # Normal approach to specifying CAM16 target space
+        elif space is not None:
+            cs = color.CS_MAP[space]
+            if not isinstance(color.CS_MAP[space], CAM16UCS):
+                raise ValueError("Distance color space must be derived from CAM16UCS.")
+            model = cs.MODEL
+            kl = COEFFICENTS[model][0]
+
         j1, a1, b1 = color.convert(space).coords(nans=False)
         j2, a2, b2 = sample.convert(space).coords(nans=False)
 

--- a/coloraide/distance/delta_e_cam16.py
+++ b/coloraide/distance/delta_e_cam16.py
@@ -41,7 +41,7 @@ class DECAM16(DeltaE):
             kl = COEFFICENTS[model][0]
 
         # Normal approach to specifying CAM16 target space
-        elif space is not None:
+        else:
             cs = color.CS_MAP[space]
             if not isinstance(color.CS_MAP[space], CAM16UCS):
                 raise ValueError("Distance color space must be derived from CAM16UCS.")

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -5,6 +5,8 @@
 -   **NEW**: Interpolation will now gracefully handle a list of a single color causing the interpolation to just return
     the single color.
 -   **NEW**: More helpful interpolation errors will raise for an empty list.
+-   **NEW**: Add new `space` method in `cam16` ∆E method to replace the now deprecate `model` parameter. `space` is more
+    flexible as users can now create CAM16 UCS spaces with different lighting environments and specify them instead.
 -   **ENHANCE**: Ray trace gamut mapping now performs faster at roughly same accuracy.
 
 ## 3.2

--- a/docs/src/markdown/distance.md
+++ b/docs/src/markdown/distance.md
@@ -238,9 +238,14 @@ and colorfulness so that a color difference metric ΔE can be based more closely
 performs distancing using the CAM16 UCS color space. If desired `model` can be changed to use the SCD or LCD model for
 "small" and "large" distancing respectively
 
-Parameter | Default | Small | Large
---------- | ------- | ----- | -----
-`model`   | `ucs`   | `scd` | `lcd`
+Parameter | Default     | Description
+--------- | ----------- | -----------
+`space`   | `cam16-ucs` | The CAM16 color space derived from the `CAM16UCS` space. `cam16-ucs`, `cam16-scd`, and `cam16-lcd` are provided in ColorAide (unregistered by default). Variants using different lighting environments can be created and registered and provided as the UCS space to operate in.
+
+/// warning | Deprecated `model` parameter
+In 3.3 the `model` parameter was deprecated and will be removed at some future time. `space` is more flexible and should
+be used instead.
+///
 
 The one or more of the CAM16 (UCS/SCD/LCD) color spaces and the ∆E algorithm must be registered to use.
 

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -824,3 +824,9 @@ class TestClosest(util.ColorAsserts, unittest.TestCase):
 
         with self.assertRaises(ValueError):
             Color('red').delta_e('blue', method='bad')
+
+    def test_bad_de_cam16_space(self):
+        """Test bad space in CAM16."""
+
+        with self.assertRaises(ValueError):
+            Color('red').delta_e('blue', method='cam16', space='lab')

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -696,7 +696,7 @@ class TestDistance(util.ColorAssertsPyTest):
         print('color1: ', color1)
         print('color2: ', color2)
         self.assertCompare(
-            Color(color1).delta_e(color2, method="cam16", model='lcd'),
+            Color(color1).delta_e(color2, method="cam16", space='cam16-lcd'),
             value,
             rounding=4
         )
@@ -732,7 +732,7 @@ class TestDistance(util.ColorAssertsPyTest):
         print('color1: ', color1)
         print('color2: ', color2)
         self.assertCompare(
-            Color(color1).delta_e(color2, method="cam16", model='scd'),
+            Color(color1).delta_e(color2, method="cam16", space='cam16-scd'),
             value,
             rounding=4
         )


### PR DESCRIPTION
- ∆Ecam16 can now have the UCS space specified via "space". This can be any space derived from CAM16UCS.