### PR TITLE
Some cleanup and fixes

### DIFF
--- a/coloraide/algebra.py
+++ b/coloraide/algebra.py
@@ -27,6 +27,7 @@ import math
 import operator
 import functools
 import itertools as it
+from .deprecate import deprecated
 from .types import (
     ArrayLike, MatrixLike, VectorLike, TensorLike, Array, Matrix, Tensor, Vector, VectorBool, MatrixBool, TensorBool,
     MatrixInt, MathType, Shape, ShapeLike, DimHints, SupportsFloatOrInt
@@ -174,10 +175,17 @@ def nth_root(n: float, p: float) -> float:
     return math.copysign(abs(n) ** (p ** -1), n)
 
 
-def npow(base: float, exp: float) -> float:
-    """Perform `pow` with a negative number."""
+def spow(base: float, exp: float) -> float:
+    """Perform `pow` with signed number."""
 
     return math.copysign(abs(base) ** exp, base)
+
+
+@deprecated("'npow' has been renamed to 'spow' (signed power), please migrate to avoid future issues.")
+def npow(base: float, exp: float) -> float:  # pragma: no cover
+    """Signed power."""
+
+    return spow(base, exp)
 
 
 def rect_to_polar(a: float, b: float) -> tuple[float, float]:

--- a/coloraide/interpolate/__init__.py
+++ b/coloraide/interpolate/__init__.py
@@ -43,7 +43,7 @@ class stop:
 def midpoint(t: float, h: float = 0.5) -> float:
     """Midpoint easing function."""
 
-    return 0.0 if h <= 0 or h >= 1 else alg.npow(t, math.log(0.5) / math.log(h))
+    return 0.0 if h <= 0 or h >= 1 else alg.spow(t, math.log(0.5) / math.log(h))
 
 
 def hint(mid: float) -> Callable[..., float]:

--- a/coloraide/spaces/a98_rgb.py
+++ b/coloraide/spaces/a98_rgb.py
@@ -8,13 +8,13 @@ from ..types import Vector
 def lin_a98rgb(rgb: Vector) -> Vector:
     """Convert an array of a98-rgb values in the range 0.0 - 1.0 to linear light (un-corrected) form."""
 
-    return [alg.npow(val, 563 / 256) for val in rgb]
+    return [alg.spow(val, 563 / 256) for val in rgb]
 
 
 def gam_a98rgb(rgb: Vector) -> Vector:
     """Convert an array of linear-light a98-rgb  in the range 0.0-1.0 to gamma corrected form."""
 
-    return [alg.npow(val, 256 / 563) for val in rgb]
+    return [alg.spow(val, 256 / 563) for val in rgb]
 
 
 class A98RGB(sRGBLinear):

--- a/coloraide/spaces/cam16_jmh.py
+++ b/coloraide/spaces/cam16_jmh.py
@@ -105,14 +105,14 @@ class Environment:
     Usage Guidelines for CIECAM97s (Nathan Moroney)
     https://www.researchgate.net/publication/220865484_Usage_guidelines_for_CIECAM97s
 
-    ref_white: The reference white XYZ. We assume XYZ is in the range 0 - 1 as that is how ColorAide
-        handles XYZ everywhere else. It will be scaled up to 0 - 100.
+    white: This is the (x, y) chromaticity points for the white point. This should be the same
+        value as set in the color class `WHITE` value.
 
     adapting_luminance: This is the the luminance of the adapting field. The units are in cd/m2.
         The equation is `L = (E * R) / π`, where `E` is the illuminance in lux, `R` is the reflectance,
         and `L` is the luminance. If we assume a perfectly reflecting diffuser, `R` is assumed as 1.
         For the "gray world" assumption, we must also divide by 5 (or multiply by 0.2 - 20%).
-        This results in `La = E / π * 0.2`.
+        This results in `La = E / π * 0.2`. Some also simplify this to simply `lux / π`.
 
     background_luminance: The background is the region immediately surrounding the stimulus and
         for images is the neighboring portion of the image. Generally, this value is set to a value of 20.
@@ -132,7 +132,7 @@ class Environment:
     def __init__(
         self,
         *,
-        reference_white: VectorLike,
+        white: VectorLike,
         adapting_luminance: float,
         background_luminance: float,
         surround: str,
@@ -146,7 +146,7 @@ class Environment:
         """
 
         self.discounting = discounting
-        self.ref_white = reference_white
+        self.ref_white = util.xy_to_xyz(white)
         self.surround = surround
 
         # The average luminance of the environment in `cd/m^2cd/m` (a.k.a. nits)
@@ -154,10 +154,11 @@ class Environment:
         # The relative luminance of the nearby background
         self.yb = background_luminance
         # Absolute luminance of the reference white.
-        yw = reference_white[1]
+        xyz_w = util.scale100(self.ref_white)
+        yw = xyz_w[1]
 
         # Cone response for reference white
-        rgb_w = alg.matmul(M16, reference_white, dims=alg.D2_D1)
+        rgb_w = alg.matmul(M16, xyz_w, dims=alg.D2_D1)
 
         # Surround: dark, dim, and average
         f, self.c, self.nc = SURROUND[self.surround]
@@ -265,11 +266,7 @@ def cam16_to_xyz_d65(
 
     # Calculate back from cone response to XYZ
     rgb_c = unadapt(alg.multiply(alg.matmul(M1, [p2, a, b], dims=alg.D2_D1), 1 / 1403, dims=alg.D1_SC), env.fl)
-    return alg.divide(
-        alg.matmul(MI6_INV, alg.multiply(rgb_c, env.d_rgb_inv, dims=alg.D1), dims=alg.D2_D1),
-        100,
-        dims=alg.D1_SC
-    )
+    return util.scale1(alg.matmul(MI6_INV, alg.multiply(rgb_c, env.d_rgb_inv, dims=alg.D1), dims=alg.D2_D1))
 
 
 def xyz_d65_to_cam16(xyzd65: Vector, env: Environment) -> Vector:
@@ -278,7 +275,7 @@ def xyz_d65_to_cam16(xyzd65: Vector, env: Environment) -> Vector:
     # Cone response
     rgb_a = adapt(
         alg.multiply(
-            alg.matmul(M16, alg.multiply(xyzd65, 100, dims=alg.D1_SC), dims=alg.D2_D1),
+            alg.matmul(M16, util.scale100(xyzd65), dims=alg.D2_D1),
             env.d_rgb,
             dims=alg.D1
         ),
@@ -357,8 +354,8 @@ class CAM16JMh(LChish, Space):
     WHITE = WHITES['2deg']['D65']
     # Assuming sRGB which has a lux of 64: `((E * R) / PI) / 5` where `R = 1`.
     ENV = Environment(
-        # D65 scaled by 100
-        reference_white=alg.multiply(util.xy_to_xyz(WHITE), 100, dims=alg.D1_SC),
+        # Our white point.
+        white=WHITE,
         # Assuming sRGB which has a lux of 64: `((E * R) / PI)` where `R = 1`.
         # Divided by 5 (or multiplied by 20%) assuming gray world.
         adapting_luminance=64 / math.pi * 0.2,

--- a/coloraide/spaces/cam16_jmh.py
+++ b/coloraide/spaces/cam16_jmh.py
@@ -94,7 +94,7 @@ def unadapt(adapted: Vector, fl: float) -> Vector:
     constant = 100 / fl * (27.13 ** ADAPTED_COEF_INV)
     for c in adapted:
         cabs = abs(c)
-        coords.append(math.copysign(constant * alg.npow(cabs / (400 - cabs), ADAPTED_COEF_INV), c))
+        coords.append(math.copysign(constant * alg.spow(cabs / (400 - cabs), ADAPTED_COEF_INV), c))
     return coords
 
 
@@ -249,13 +249,13 @@ def cam16_to_xyz_d65(
         alpha = (M / env.fl_root) / J_root
     elif s is not None:
         alpha = 0.0004 * (s ** 2) * (env.a_w + 4) / env.c
-    t = alg.npow(alpha * math.pow(1.64 - math.pow(0.29, env.n), -0.73), 10 / 9)
+    t = alg.spow(alpha * math.pow(1.64 - math.pow(0.29, env.n), -0.73), 10 / 9)
 
     # Eccentricity
     et = 0.25 * (math.cos(h_rad + 2) + 3.8)
 
     # Achromatic response
-    A = env.a_w * alg.npow(J_root, 2 / env.c / env.z)
+    A = env.a_w * alg.spow(J_root, 2 / env.c / env.z)
 
     # Calculate red-green and yellow-blue components
     p1 = 5e4 / 13 * env.nc * env.ncb * et
@@ -294,15 +294,15 @@ def xyz_d65_to_cam16(xyzd65: Vector, env: Environment) -> Vector:
         5e4 / 13 * env.nc * env.ncb *
         alg.zdiv(et * math.sqrt(a ** 2 + b ** 2), rgb_a[0] + rgb_a[1] + 1.05 * rgb_a[2] + 0.305)
     )
-    alpha = alg.npow(t, 0.9) * math.pow(1.64 - math.pow(0.29, env.n), 0.73)
+    alpha = alg.spow(t, 0.9) * math.pow(1.64 - math.pow(0.29, env.n), 0.73)
 
     # Achromatic response
     A = env.nbb * (2 * rgb_a[0] + rgb_a[1] + 0.05 * rgb_a[2])
 
-    J_root = alg.npow(A / env.a_w, 0.5 * env.c * env.z)
+    J_root = alg.spow(A / env.a_w, 0.5 * env.c * env.z)
 
     # Lightness
-    J = 100 * alg.npow(J_root, 2)
+    J = 100 * alg.spow(J_root, 2)
 
     # Brightness
     Q = (4 / env.c * J_root * (env.a_w + 4) * env.fl_root)

--- a/coloraide/spaces/hct.py
+++ b/coloraide/spaces/hct.py
@@ -43,7 +43,6 @@ color(--hct 256.79 31.766 33.344 / 1)
 """
 from __future__ import annotations
 from .. import algebra as alg
-from .. import util
 from ..spaces import Space, LChish
 from ..cat import WHITES
 from ..channels import Channel, FLG_ANGLE
@@ -155,8 +154,8 @@ class HCT(LChish, Space):
     SERIALIZE = ("--hct",)
     WHITE = WHITES['2deg']['D65']
     ENV = Environment(
-        # D65 scaled by 100
-        reference_white=alg.multiply(util.xy_to_xyz(WHITE), 100, dims=alg.D1_SC),
+        # D65 white point.
+        white=WHITE,
         # 200 lux or `~11.72 cd/m2` multiplied by ~18.42%, a variation of gray world assumption.
         adapting_luminance=200 / math.pi * lstar_to_y(50.0),
         # A variation on gray world assumption: ~18.42% of reference white's `Yw == 100`.

--- a/coloraide/spaces/hpluv.py
+++ b/coloraide/spaces/hpluv.py
@@ -82,7 +82,7 @@ def hpluv_to_luv(hpluv: Vector) -> Vector:
         l = 0.0
     else:
         _hx_max = max_safe_chroma_for_l(l)
-        c = _hx_max / 100 * s
+        c = _hx_max * 0.01 * s
     a, b = alg.polar_to_rect(c, h)
     return [l, a, b]
 

--- a/coloraide/spaces/hsluv.py
+++ b/coloraide/spaces/hsluv.py
@@ -84,7 +84,7 @@ def hsluv_to_luv(hsluv: Vector) -> Vector:
         l = 0.0
     else:
         _hx_max = max_chroma_for_lh(l, h)
-        c = _hx_max / 100.0 * s
+        c = _hx_max * 0.01 * s
 
     a, b = alg.polar_to_rect(c, h)
     return [l, a, b]

--- a/coloraide/spaces/hunter_lab.py
+++ b/coloraide/spaces/hunter_lab.py
@@ -42,11 +42,11 @@ def hlab_to_xyz(hlab: Vector, white: VectorLike) -> Vector:
     ka = CKA * alg.nth_root(xn / CXN, 2)
     kb = CKB * alg.nth_root(zn / CZN, 2)
     l, a, b = hlab
-    l /= 100
+    l *= 0.01
     y = (l ** 2) * yn
     x = (((a * l) / ka) + (y / yn)) * xn
     z = (((b * l) / kb) - (y / yn)) * -zn
-    return alg.divide([x, y, z], 100, dims=alg.D1_SC)
+    return alg.multiply([x, y, z], 0.01, dims=alg.D1_SC)
 
 
 class HunterLab(Lab):

--- a/coloraide/spaces/ictcp.py
+++ b/coloraide/spaces/ictcp.py
@@ -50,6 +50,8 @@ ictcp_to_lms_p_mi = [
     [1.0, 0.5600313357106791, -0.32062717498731885]
 ]
 
+YW = 203
+
 
 def ictcp_to_xyz_d65(ictcp: Vector) -> Vector:
     """From ICtCp to XYZ."""
@@ -64,14 +66,14 @@ def ictcp_to_xyz_d65(ictcp: Vector) -> Vector:
     absxyz = alg.matmul(lms_to_xyz_mi, lms, dims=alg.D2_D1)
 
     # Convert back to normal XYZ D65
-    return util.absxyz_to_xyz(absxyz)
+    return util.absxyz_to_xyz(absxyz, YW)
 
 
 def xyz_d65_to_ictcp(xyzd65: Vector) -> Vector:
     """From XYZ to ICtCp."""
 
     # Convert from XYZ D65 to an absolute XYZ D65
-    absxyz = util.xyz_to_absxyz(xyzd65)
+    absxyz = util.xyz_to_absxyz(xyzd65, YW)
 
     # Convert to LMS
     lms = alg.matmul(xyz_to_lms_m, absxyz, dims=alg.D2_D1)

--- a/coloraide/spaces/igpgtg.py
+++ b/coloraide/spaces/igpgtg.py
@@ -40,9 +40,9 @@ def xyz_to_igpgtg(xyz: Vector) -> Vector:
 
     lms_in = alg.matmul(XYZ_TO_LMS, xyz, dims=alg.D2_D1)
     lms = [
-        alg.npow(lms_in[0] / 18.36, 0.427),
-        alg.npow(lms_in[1] / 21.46, 0.427),
-        alg.npow(lms_in[2] / 19435, 0.427)
+        alg.spow(lms_in[0] / 18.36, 0.427),
+        alg.spow(lms_in[1] / 21.46, 0.427),
+        alg.spow(lms_in[2] / 19435, 0.427)
     ]
     return alg.matmul(LMS_TO_IGPGTG, lms, dims=alg.D2_D1)
 

--- a/coloraide/spaces/ipt.py
+++ b/coloraide/spaces/ipt.py
@@ -39,7 +39,7 @@ IPT_TO_LMS_P = [
 def xyz_to_ipt(xyz: Vector) -> Vector:
     """XYZ to IPT."""
 
-    lms_p = [alg.npow(c, 0.43) for c in alg.matmul(XYZ_TO_LMS, xyz, dims=alg.D2_D1)]
+    lms_p = [alg.spow(c, 0.43) for c in alg.matmul(XYZ_TO_LMS, xyz, dims=alg.D2_D1)]
     return alg.matmul(LMS_P_TO_IPT, lms_p, dims=alg.D2_D1)
 
 

--- a/coloraide/spaces/jzczhz.py
+++ b/coloraide/spaces/jzczhz.py
@@ -6,9 +6,7 @@ https://www.osapublishing.org/oe/fulltext.cfm?uri=oe-25-13-15131&id=368272
 from __future__ import annotations
 from ..cat import WHITES
 from .lch import LCh
-from .jzazbz import ACHROMATIC_THRESHOLD  # type: ignore[attr-defined]
 from ..channels import Channel, FLG_ANGLE
-from ..types import Vector
 
 
 class JzCzhz(LCh):
@@ -36,12 +34,6 @@ class JzCzhz(LCh):
         Channel("cz", 0.0, 1.0),
         Channel("hz", 0.0, 360.0, flags=FLG_ANGLE)
     )
-
-    def is_achromatic(self, coords: Vector) -> bool:
-        """Check if color is achromatic."""
-
-        # Account for both positive and negative chroma
-        return coords[0] < 0 or abs(coords[1]) < ACHROMATIC_THRESHOLD
 
     def hue_name(self) -> str:
         """Hue name."""

--- a/coloraide/spaces/prophoto_rgb.py
+++ b/coloraide/spaces/prophoto_rgb.py
@@ -24,7 +24,7 @@ def lin_prophoto(rgb: Vector) -> Vector:
         if abs(i) < ET2:
             result.append(i / 16.0)
         else:
-            result.append(alg.npow(i, 1.8))
+            result.append(alg.spow(i, 1.8))
     return result
 
 

--- a/coloraide/spaces/rec2100_pq.py
+++ b/coloraide/spaces/rec2100_pq.py
@@ -9,6 +9,8 @@ from .srgb_linear import sRGBLinear
 from ..types import Vector
 from .. import util
 
+YW = 203
+
 
 class Rec2100PQ(sRGBLinear):
     """Rec. 2100 PQ class."""
@@ -25,11 +27,11 @@ class Rec2100PQ(sRGBLinear):
         return self.BASE
 
     def to_base(self, coords: Vector) -> Vector:
-        """To XYZ from Rec. 2100 PQ."""
+        """To base from Rec. 2100 PQ."""
 
-        return [max(c / util.YW, 0.0) for c in util.pq_st2084_eotf(coords)]
+        return [c / YW for c in util.pq_st2084_eotf(coords)]
 
     def from_base(self, coords: Vector) -> Vector:
-        """From XYZ to Rec. 2100 PQ."""
+        """From base to Rec. 2100 PQ."""
 
-        return util.pq_st2084_oetf([max(c * util.YW, 0.0) for c in coords])
+        return util.pq_st2084_oetf([c * YW for c in coords])

--- a/coloraide/spaces/rlab.py
+++ b/coloraide/spaces/rlab.py
@@ -54,14 +54,14 @@ class Environment:
     def __init__(
         self,
         *,
-        reference_white: VectorLike,
+        white: VectorLike,
         adapting_luminance: float,
         surround: str,
         discounting: str
     ) -> None:
         """Initialize."""
 
-        self.ref_white = alg.multiply(reference_white, 0.01, dims=alg.D1_SC)
+        self.ref_white = util.xy_to_xyz(white)
         self.surround = SURROUND[surround]
         self.yn = adapting_luminance
         self.d = alg.clamp(D[discounting] if isinstance(discounting, str) else discounting, 0.0, 1.0)
@@ -86,7 +86,7 @@ def rlab_to_xyz(rlab: Vector, env: Environment) -> Vector:
     """RLAB to XYZ."""
 
     LR, aR, bR = rlab
-    yr = LR / 100
+    yr = LR * 0.01
     xr = alg.npow((aR / 430) + yr, env.surround)
     zr = alg.npow(yr - (bR / 170), env.surround)
     return alg.matmul(env.iram, [xr, alg.npow(yr, env.surround), zr], dims=alg.D2_D1)
@@ -118,8 +118,8 @@ class RLAB(Lab):
     # Using less than full discounting would require special achromatic handling
     # to identify achromatic colors as `a == b == 0.0` would no longer be true.
     ENV = Environment(
-        # D65 scaled by 100
-        reference_white=alg.multiply(util.xy_to_xyz(WHITE), 100, dims=alg.D1_SC),
+        # D65 white point.
+        white=WHITE,
         # 1000 lux or `~318.31 cd/m2`
         adapting_luminance=YN,
         # Average surround

--- a/coloraide/spaces/rlab.py
+++ b/coloraide/spaces/rlab.py
@@ -87,9 +87,9 @@ def rlab_to_xyz(rlab: Vector, env: Environment) -> Vector:
 
     LR, aR, bR = rlab
     yr = LR * 0.01
-    xr = alg.npow((aR / 430) + yr, env.surround)
-    zr = alg.npow(yr - (bR / 170), env.surround)
-    return alg.matmul(env.iram, [xr, alg.npow(yr, env.surround), zr], dims=alg.D2_D1)
+    xr = alg.spow((aR / 430) + yr, env.surround)
+    zr = alg.spow(yr - (bR / 170), env.surround)
+    return alg.matmul(env.iram, [xr, alg.spow(yr, env.surround), zr], dims=alg.D2_D1)
 
 
 def xyz_to_rlab(xyz: Vector, env: Environment) -> Vector:

--- a/coloraide/util.py
+++ b/coloraide/util.py
@@ -21,13 +21,6 @@ DEF_CONTRAST = "wcag21"
 DEF_CCT = "robertson-1968"
 DEF_INTERPOLATOR = "linear"
 
-# Maximum luminance in PQ is 10,000 cd/m^2
-# Relative XYZ has Y=1 for media white
-# BT.2048 says media white Y=203 at PQ 58
-#
-# This is confirmed here: https://www.itu.int/dms_pub/itu-r/opb/rep/R-REP-BT.2408-3-2019-PDF-E.pdf
-YW = 203
-
 # PQ Constants
 # https://en.wikipedia.org/wiki/High-dynamic-range_video#Perceptual_quantizer
 M1 = 2610 / 16384
@@ -122,6 +115,27 @@ def pq_st2084_oetf(
     return adjusted
 
 
+def pq_st2084_eotf(
+    values: VectorLike,
+    c1: float = C1,
+    c2: float = C2,
+    c3: float = C3,
+    m1: float = M1,
+    m2: float = M2
+) -> Vector:
+    """Perceptual quantizer (SMPTE ST 2084) - EOTF."""
+
+    im1 = 1 / m1
+    im2 = 1 / m2
+
+    adjusted = []
+    for c in values:
+        c = alg.npow(c, im2)
+        r = max((c - c1), 0) / (c2 - c3 * c)
+        adjusted.append(10000 * alg.npow(r, im1))
+    return adjusted
+
+
 def rgb_scale(vec: VectorLike) -> Vector:
     """
     Scale the RGB vector.
@@ -142,37 +156,28 @@ def rgb_scale(vec: VectorLike) -> Vector:
     return [v / m if m else v for v in vec]
 
 
-def pq_st2084_eotf(
-    values: VectorLike,
-    c1: float = C1,
-    c2: float = C2,
-    c3: float = C3,
-    m1: float = M1,
-    m2: float = M2
-) -> Vector:
-    """Perceptual quantizer (SMPTE ST 2084) - EOTF."""
+def scale100(coords):
+    """Scale from 1 to 100."""
 
-    im1 = 1 / m1
-    im2 = 1 / m2
-
-    adjusted = []
-    for c in values:
-        c = alg.npow(c, im2)
-        r = (c - c1) / (c2 - c3 * c)
-        adjusted.append(10000 * alg.npow(r, im1))
-    return adjusted
+    return [c * 100 for c in coords]
 
 
-def xyz_to_absxyz(xyzd65: VectorLike, yw: float = YW) -> Vector:
+def scale1(coords):
+    """Scale from 1 to 100."""
+
+    return [c * 0.01 for c in coords]
+
+
+def xyz_to_absxyz(xyzd65: VectorLike, yw: float = 100) -> Vector:
     """XYZ to Absolute XYZ."""
 
-    return [max(c * yw, 0) for c in xyzd65]
+    return [c * yw for c in xyzd65]
 
 
-def absxyz_to_xyz(absxyzd65: VectorLike, yw: float = YW) -> Vector:
+def absxyz_to_xyz(absxyzd65: VectorLike, yw: float = 100) -> Vector:
     """Absolute XYZ to XYZ."""
 
-    return [max(c / yw, 0) for c in absxyzd65]
+    return [c / yw for c in absxyzd65]
 
 
 def constrain_hue(hue: float) -> float:

--- a/coloraide/util.py
+++ b/coloraide/util.py
@@ -156,13 +156,13 @@ def rgb_scale(vec: VectorLike) -> Vector:
     return [v / m if m else v for v in vec]
 
 
-def scale100(coords):
+def scale100(coords: Vector) -> Vector:
     """Scale from 1 to 100."""
 
     return [c * 100 for c in coords]
 
 
-def scale1(coords):
+def scale1(coords: Vector) -> Vector:
     """Scale from 1 to 100."""
 
     return [c * 0.01 for c in coords]

--- a/coloraide/util.py
+++ b/coloraide/util.py
@@ -109,9 +109,8 @@ def pq_st2084_oetf(
 
     adjusted = []
     for c in values:
-        c = alg.npow(c / 10000, m1)
-        r = (c1 + c2 * c) / (1 + c3 * c)
-        adjusted.append(alg.npow(r, m2))
+        c = alg.spow(c / 10000, m1)
+        adjusted.append(alg.spow((c1 + c2 * c) / (1 + c3 * c), m2))
     return adjusted
 
 
@@ -130,9 +129,8 @@ def pq_st2084_eotf(
 
     adjusted = []
     for c in values:
-        c = alg.npow(c, im2)
-        r = max((c - c1), 0) / (c2 - c3 * c)
-        adjusted.append(10000 * alg.npow(r, im1))
+        c = alg.spow(c, im2)
+        adjusted.append(10000 * alg.spow(max((c - c1), 0) / (c2 - c3 * c), im1))
     return adjusted
 
 

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -197,6 +197,7 @@ XYZ
 YCbCr
 Yoshi
 ZD
+absolutizing
 accessor
 accessors
 achromatomaly

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,7 +1,13 @@
 # Changelog
 
-## 3.3
+## 3.2
 
+-   **NEW**: `cam16-jmh`, `cam16-ucs`, `jzczhz`, `jzazbz`, `ipt`, and `igpgtg` will perform achromatic handling relative
+    to themselves. As an example, in CAM16, when chroma is close to zero, color will be determined as achromatic. This
+    is due to adapting luminance and background luminance, zero chroma may not always be perfect white, but it is
+    achromatic according to the space. This simplifies logic, improves speed, and lessens confusion as to what
+    achromatic means.
+-   **NEW**: Remove deprecated CAM16 Jab implementation. Use `cam16-ucs` instead.
 -   **NEW**: Interpolation will now gracefully handle a list of a single color causing the interpolation to just return
     the single color.
 -   **NEW**: More helpful interpolation errors will raise for an empty list.
@@ -15,18 +21,8 @@
 -   **NEW**: Rename `algebra.npow` to `algebra.spow` (signed power). `algebra.npow` is now deprecated and will be
     removed at some future time.
 -   **ENHANCE**: Ray trace gamut mapping now performs faster at roughly same accuracy.
--   **FIX**: Don't force space to clamp negative XYZ when they are absolutizing them in some spaces. This allows better
-    round trip values when the color space can handle them.
+-   **FIX**: Don't force space to clamp negative XYZ when they are absolutizing them in some spaces.
 -   **FIX**: Ensure ST2084 EOTF implements the `max` as specified in the spec.
-
-## 3.2
-
--   **NEW**: `cam16-jmh`, `cam16-ucs`, `jzczhz`, `jzazbz`, `ipt`, and `igpgtg` will perform achromatic handling relative
-    to themselves. As an example, in CAM16, when chroma is close to zero, color will be determined as achromatic. This
-    is due to adapting luminance and background luminance, zero chroma may not always be perfect white, but it is
-    achromatic according to the space. This simplifies logic, improves speed, and lessens confusion as to what
-    achromatic means.
--   **NEW**: Remove deprecated CAM16 Jab implementation. Use `cam16-ucs` instead.
 
 ## 3.1.2
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -12,6 +12,8 @@
 -   **NEW**: Generic ray trace gamut mapping now has a new `pspace` parameter that can be used to specify a perceptual
     space in either LCh-ish or Lab-ish form. `lch` parameter is now deprecated, but currently still present, but
     `pspace` will take priority if both are defined.
+-   **NEW**: Rename `algebra.npow` to `algebra.spow` (signed power). `algebra.npow` is now deprecated and will be
+    removed at some future time.
 -   **ENHANCE**: Ray trace gamut mapping now performs faster at roughly same accuracy.
 -   **FIX**: Don't force space to clamp negative XYZ when they are absolutizing them in some spaces. This allows better
     round trip values when the color space can handle them.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -13,6 +13,9 @@
     space in either LCh-ish or Lab-ish form. `lch` parameter is now deprecated, but currently still present, but
     `pspace` will take priority if both are defined.
 -   **ENHANCE**: Ray trace gamut mapping now performs faster at roughly same accuracy.
+-   **FIX**: Don't force space to clamp negative XYZ when they are absolutizing them in some spaces. This allows better
+    round trip values when the color space can handle them.
+-   **FIX**: Ensure ST2084 EOTF implements the `max` as specified in the spec.
 
 ## 3.2
 

--- a/docs/src/markdown/colors/cam16_jmh.md
+++ b/docs/src/markdown/colors/cam16_jmh.md
@@ -63,7 +63,7 @@ appear different based on the viewing conditions.
 
 Viewing\ Conditions    | Description
 ---------------------- | -----------
-Reference\ White       | The XYZ values of the reference white scaled by 100.
+White                  | This is the white point and should be the same as defined in the color class. This is provided as (x, y) chromaticity coordinates.
 Adapting\ Luminance    | The luminance of the adapting field (`La`). The units are in cd/m2.
 Background\ Luminance  | The background luminance (`Yb`) the relative luminance of the nearby background (out to 10°), relative to the the reference white's luminance (`Y`). Usually 20 providing a gray world assumption.
 Surround               | A description of the peripheral area. Use "dark" for a movie theater, "dim" for e.g. viewing a bright television in a dimly lit room, or "average" for surface colors.
@@ -89,7 +89,7 @@ class CustomCAM16JMh(CAM16JMh):
     SERIALIZE = ("--cam16-custom",)
     WHITE = WHITES['2deg']['D65']
     ENV = Environment(
-        reference_white=[x * 100 for x in util.xy_to_xyz(WHITE)],
+        white=WHITE,
         adapting_luminance=1000 / math.pi,
         background_luminance=20,
         surround='average',

--- a/docs/src/markdown/colors/rlab.md
+++ b/docs/src/markdown/colors/rlab.md
@@ -48,14 +48,14 @@ conditions.
 
 Viewing\ Conditions    | Description
 ---------------------- | -----------
-`white`                | The XYZ values of the reference white scaled by 100.
+`white`                | This is the white point and should be the same as defined in the color class. This is provided as (x, y) chromaticity coordinates.
 `adapting_luminance`   | The luminance of the adapting field (often known as `La`). The units are in cd/m2.
 `surround`             | A description of the peripheral area. Use "dark" for a movie theater, "dim" for e.g. viewing a bright television in a dimly lit room, or "average" for surface colors.
 `discounting`          | Degree of discounting of the illuminant. A string of either "hard-copy", "projected-transparency", or "soft-copy". Hard copy indicates full discount, or the eye is assumed to be fully adapted to the illuminant. Projected transparency performs 50% discount.
 
 ColorAide must provide some defaults, so the RLAB space has a default set of viewing conditions that uses a D65 white
 point, an adapting luminance of 1000 lux or a value of ~318.31 cd/m^2^, an "average" surround, and sets discounting to
-"hard-copy".
+"hard-copy". These are the same settings that were demonstrated in the original paper.
 
 These settings do not have to be used, and a new RLAB variant with different viewing conditions can be created. When
 doing this, the space should be derived from the default RLAB space.
@@ -72,7 +72,7 @@ class CustomRLAB(RLAB):
     SERIALIZE = ("--rlab-custom",)
     WHITE = WHITES['2deg']['D65']
     ENV = Environment(
-        reference_white=[x * 100 for x in util.xy_to_xyz(WHITE)],
+        white=WHITE,
         adapting_luminance=64 / math.pi * 0.2,
         surround='average',
         discounting="soft-copy"

--- a/docs/src/markdown/gamut.md
+++ b/docs/src/markdown/gamut.md
@@ -519,7 +519,8 @@ Consider the example below. We take a very saturated yellow in Display P3 (`#!co
 we interpolate it's whiteness between 0, masking off chroma so that we are only interpolating lightness. We do this
 interpolation in CIELCh, which is known to have chroma that can swing very far outside the visible spectrum when
 interpolating hues at more extreme lightness. Finally, we gamut map in various LCh models. What we can observe is some
-models will struggle to map some of these colors as the models hue preservation can break down at extreme limits.
+models will struggle to map some of these colors as the hue preservation can break down at extreme limits. In the cases
+below, this specifically happens due to negative XYZ values that are produced due to high chroma in lower lightness.
 Some models can tolerate this more than others.
 
 ```py play
@@ -532,15 +533,13 @@ Steps([c.fit('srgb', method='raytrace', pspace='jzczhz') for c in Color.steps([y
 Steps([c.fit('srgb', method='raytrace', pspace='lchuv') for c in Color.steps([yellow, lightness_mask], steps=20, space='lch')])
 ```
 
-Each perceptual model above will bend the the hues to be perceptual and scale lightness and chroma a bit differently,
-and at the edge of the visual spectrum, it is not uncommon to see larger shifts in hues as these color spaces are not
-meant to be perceptual infinitely out into imaginary colors. Converting between these spaces _before_ reducing chroma
-can introduce such disparities. If you push any color space far enough, they all will break down in some way, some are
-more tolerable than others.
+Almost any perceptual model, if pushed far enough, can start to break down. Converting to and from these spaces _before_
+reducing chroma can introduce such disparities. Every color space has limitations, some spaces just have more agreeable
+ones.
 
 If you are working within reasonable gamuts, most will work just fine. And if you want to do something like above,
 holding chroma really high for all lightness values, you will often find that it works best when you do it directly in
-the color space that is doing the gamut mapping as you will have "fit" the color before converting to another color
+the color space that is doing the gamut mapping as you will have to "fit" the color before converting to another color
 space.
 
 
@@ -561,8 +560,6 @@ yellow = Color('color(display-p3 1 1 0)')
 lightness_mask = Color('color(--lchuv 0% none none)')
 Steps([c.fit('srgb', method='raytrace', pspace='lchuv') for c in Color.steps([yellow, lightness_mask], steps=20, space='lchuv')])
 ```
-
-Every color space has limitations, some spaces just have more agreeable ones.
 
 ## Why Not Just Clip?
 

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -1799,9 +1799,9 @@ class TestAlgebra(unittest.TestCase):
     def test_apply_two_inputs(self):
         """Test vectorize2 with two inputs."""
 
-        npow = alg.vectorize2(alg.npow)
+        spow = alg.vectorize2(alg.spow)
         self.assertEqual(
-            npow([[1, 2, 3], [4, 5, 6]], 2),
+            spow([[1, 2, 3], [4, 5, 6]], 2),
             [[1, 4, 9], [16, 25, 36]]
         )
 

--- a/tests/test_gamut.py
+++ b/tests/test_gamut.py
@@ -126,7 +126,7 @@ class TestGamut(util.ColorAsserts, unittest.TestCase):
         """Test HDR extreme high case."""
 
         color = Color('color(--rec2100-pq 1.01 0.2 0)')
-        self.assertColorEqual(color.fit(), Color('color(--rec2100-pq 1 0.45327 0)'))
+        self.assertColorEqual(color.fit(), Color('color(rec2100-pq 1 0.63544 1)'))
 
     def test_hdr_extreme_low(self):
         """Test HDR extreme low case."""


### PR DESCRIPTION
- Add utility functions to do common scaling from 1 to 100 and 100 to 1
- Absolute value XYZ conversion won't force clamping of negative values.
- Ensure ST2084 EOTF implements the max step as specified in the spec.
- Rework environment objects to accept white points as chromaticity points as it was done previously.