### PR TITLE
Add layer() and deprecate compose()

### DIFF
--- a/coloraide/color.py
+++ b/coloraide/color.py
@@ -17,6 +17,7 @@ from . import average
 from . import temperature
 from . import util
 from . import algebra as alg
+from .deprecate import deprecated
 from itertools import zip_longest as zipl
 from .css import parse
 from .types import VectorLike, Vector, ColorInput
@@ -1194,6 +1195,7 @@ class Color(metaclass=ColorMeta):
 
         return [c.convert(out_space, in_place=True) for c in harmonies.harmonize(self, name, space, **kwargs)]
 
+    @deprecated('Please use the class method Color.layer([source, backdrop])')
     def compose(
         self,
         backdrop: ColorInput | Sequence[ColorInput],
@@ -1203,7 +1205,7 @@ class Color(metaclass=ColorMeta):
         space: str | None = None,
         out_space: str | None = None,
         in_place: bool = False
-    ) -> Color:
+    ) -> Color:  # pragma: no cover
         """Blend colors using the specified blend mode."""
 
         if not isinstance(backdrop, str) and isinstance(backdrop, Sequence):
@@ -1214,6 +1216,24 @@ class Color(metaclass=ColorMeta):
 
         color = compositing.compose(type(self), colors, blend, operator, space, out_space)
         return self._hotswap(color) if in_place else color
+
+    @classmethod
+    def layer(
+        cls,
+        colors: Sequence[ColorInput],
+        *,
+        blend: str | bool = True,
+        operator: str | bool = True,
+        space: str | None = None,
+        out_space: str | None = None
+    ) -> Color:
+        """
+        Apply color compositing (blend modes and alpha blending) on a list of colors.
+
+        Colors are overlaid on each other with left being the top of the stack and right being the bottom of the stack.
+        """
+
+        return compositing.compose(cls, colors, blend, operator, space, out_space)
 
     def delta_e(
         self,

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -25,6 +25,9 @@
     of L = 50%.
 -   **NEW**: Remove deprecated `lab` parameter from experimental `raytrace` gamut mapping method. Users should use
     `pspace` instead to specify the perceptual space to use.
+-   **NEW**: Class method `layer()` added to replace `compose()` with a multi-color handling similar to other API
+    methods such as `interpolate()`, etc.
+-   **NEW**: `compose()` has been deprecated in favor of the new `layer()` method.
 -   **BREAK**: The experimental `raytrace` gamut mapping method now uses OkLCh by default instead of CIELCh (D65).
 -   **BREAK**: Pre-configured `oklch-raytrace` and `lch-raytrace` variants of the experimental `raytrace` gamut mapping
     method have been removed to reduce included plugins. OkLCh is the default now and users can still specify CIELCh and

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -27,7 +27,8 @@
     `pspace` instead to specify the perceptual space to use.
 -   **NEW**: Class method `layer()` added to replace `compose()` with a multi-color handling similar to other API
     methods such as `interpolate()`, etc.
--   **NEW**: `compose()` has been deprecated in favor of the new `layer()` method.
+-   **NEW**: `compose()` has been deprecated in favor of the new `layer()` method and will be removed at some future
+    time.
 -   **BREAK**: The experimental `raytrace` gamut mapping method now uses OkLCh by default instead of CIELCh (D65).
 -   **BREAK**: Pre-configured `oklch-raytrace` and `lch-raytrace` variants of the experimental `raytrace` gamut mapping
     method have been removed to reduce included plugins. OkLCh is the default now and users can still specify CIELCh and

--- a/docs/src/markdown/api/index.md
+++ b/docs/src/markdown/api/index.md
@@ -57,6 +57,7 @@ Parameters
 def hint(
     mid: float,
 ) -> Callable[..., float]:
+    ...
 ```
 
 /// define
@@ -336,6 +337,7 @@ Return
 def clone(
     self
 ):
+    ...
 ```
 
 /// define
@@ -599,7 +601,6 @@ def luminance(
     self,
     *,
     white: VectorLike | None = cat.WHITES['2deg']['D65']
-
 ) -> float:
     ...
 ```
@@ -1032,6 +1033,7 @@ def average(
     powerelss: bool | None = None
     **kwargs: Any
 ) -> Color:
+    ...
 ```
 
 /// define
@@ -1177,7 +1179,7 @@ Return
 ## `#!py Color.compose` {#compose}
 
 /// warning | Deprecated 4.0
-`compose` method was deprecated in favor of the new [`layer`](#layer) method.
+`compose` method was deprecated in favor of the new [`layer`](#layer) method and will be removed at some future time.
 ///
 
 ```py
@@ -1254,6 +1256,7 @@ def layer(
     space: str | None = None,
     out_space: str | None = None
 ) -> Color:
+    ...
 ```
 
 /// define
@@ -1309,6 +1312,7 @@ def clip(
     self,
     space: str | None = None
 ) -> Color:
+    ...
 ```
 
 /// define
@@ -1382,6 +1386,7 @@ def in_gamut(
     *,
     tolerance: float = util.DEF_FIT_TOLERANCE
 ) -> bool:
+    ...
 ```
 
 /// define
@@ -1411,6 +1416,7 @@ def get(
     *,
     nans: bool = True
 ) -> float | list[float]:
+    ...
 ```
 
 /// define
@@ -1444,6 +1450,7 @@ def set(
     *,
     nans: bool = True
 ) -> Color:
+    ...
 ```
 
 /// define
@@ -1616,6 +1623,7 @@ def blackbody(
     method: str | None = None,
     **kwargs: Any
 ) -> Color:
+    ...
 ```
 
 /// define
@@ -1652,6 +1660,7 @@ def cct(
     method: str | None = None,
     **kwargs: Any
 ) -> Vector:
+    ...
 ```
 
 /// define
@@ -1718,6 +1727,7 @@ def xy(
     *,
     white: VectorLike | None = None
 ) -> Vector:
+    ...
 ```
 
 /// define

--- a/docs/src/markdown/api/index.md
+++ b/docs/src/markdown/api/index.md
@@ -643,7 +643,7 @@ Parameters
 - 
     Parameters | Defaults     | Description
     ---------- | -------------| -----------
-    `color`    |              | A color string or [`Color`](#color) object representing a color.
+    `color`    |              | A color string, [`Color`](#color) object, or dictionary representing a color.
     `method`   | `#!py None`  | Specify the method used to obtain the contrast value. If `#!py None`, the default specified by the class will be used.
 
 Return
@@ -673,7 +673,7 @@ Parameters
 - 
     Parameters | Defaults     | Description
     ---------- | ------------ | -----------
-    `color`    |              | A color string or [`Color`](#color) object representing a color.
+    `color`    |              | A color string, [`Color`](#color) object, or dictionary representing a color.
     `space`    | `#!py3 "lab"`| Color space to perform distancing algorithm in.
 
 Return
@@ -722,7 +722,7 @@ Parameters
 - 
     Parameters | Defaults     | Description
     ---------- | ------------ | -----------
-    `color`    |              | A color string or [`Color`](#color) object representing a color.
+    `color`    |              | A color string, [`Color`](#color) object, or dictionary representing a color.
     `method`   | `#!py None`  | String that specifies the method to use. If `#!py3 None`, the default will be used.
     `**kwargs` |              | Any distancing specific parameters to pass to ∆E method.
 
@@ -1007,7 +1007,7 @@ Parameters
 - 
     Parameters                 | Defaults                           | Description
     -------------------------- | ---------------------------------- | -----------
-    `color`                    |                                    | A color string, [`Color`](#color) object, and/or dictionary representing a color.
+    `color`                    |                                    | A color string, [`Color`](#color) object, or dictionary representing a color.
     `percent`                  | `#!py 0.5`                         | A numerical value between 0 - 1 representing the percentage at which the parameter `color` will be mixed.
     `in_place`                 | `#!py False`                       | Boolean used to determine if the the current color should be modified "in place" or a new [`Color`](#color) object should be returned.
     `#!py **interpolate_args`  | See\ [`interpolate`](#interpolate) | Keyword arguments defined in [`interpolate`](#interpolate).
@@ -1109,7 +1109,7 @@ Parameters
     `name`      |                | The name of the filter that should be applied.
     `amount`    | See\ above     | A numerical value adjusting to what degree the filter is applied. Input range can vary depending on the filter being used. Default can also dependent on the filter being used.
     `space`     | `#!py3 None`   | Controls the algorithm used for simulating the given CVD.
-    `in_place`  | `#!py3 False`  | Boolean used to determine if the the current color should be modified "in place" or a new [`Color`](#color) object should be returned. 
+    `in_place`  | `#!py3 False`  | Boolean used to determine if the the current color should be modified "in place" or a new [`Color`](#color) object should be returned.
     `out_space` | `#!py None`    | Color space that the new color should be in. If `#!py None`, the return color will be in the same color space as specified via `space`.
     `**kwargs`  |                | Additional filter specific parameters.
 
@@ -1176,6 +1176,10 @@ Return
 
 ## `#!py Color.compose` {#compose}
 
+/// warning | Deprecated 4.0
+`compose` method was deprecated in favor of the new [`layer`](#layer) method.
+///
+
 ```py
 def compose(
     self,
@@ -1197,8 +1201,8 @@ Description
     for alpha compositing. The current color is treated as the source (top layer) and the provided color as the backdrop
     (bottom layer). Colors will be composited in the `srgb` color space unless otherwise specified.
 
-    Colors should generally be RGB-ish colors (sRGB, Display P3, A98 RGB, etc.). The algorithm is designed only for
-    RGB-ish colors. Non-RGB-ish colors are likely to provide nonsense results.
+    Compositing should generally be applied in RGB-ish color spaces (sRGB, Display P3, A98 RGB, etc.). The algorithm is
+    designed only for RGB-ish colors. Non-RGB-ish colors are likely to provide nonsense results.
 
     Supported blend modes are:
 
@@ -1224,7 +1228,7 @@ Parameters
 - 
     Parameters  | Defaults       | Description
     ----------- | -------------- | -----------
-    `backdrop`  |                | A background color represented with either a string or [`Color`](#color) object.
+    `backdrop`  |                | A background color or sequence of background colors represented with strings, [`Color`](#color) objects, and/or dictionaries representing a color.
     `blend`     | `#!py3 None`   | A blend mode to use to use when compositing. Values should be a string specifying the name of the blend mode to use. If `#!py None`, [`normal`](#normal) will be used. If `#!py False`, blending will be skipped.
     `operator`  | `#!py3 None`   | A Porter Duff operator to use for alpha compositing. Values should be a string specifying the name of the operator to use. If `#!py None`, [`source-over`](#source-over) will be used. If `#!py False`, alpha compositing will be skipped.
     `space`     | `#!py3 None`   | A color space to perform the overlay in. If `#!py None`, the base color's space will be used.
@@ -1235,6 +1239,67 @@ Return
 
 -   Returns a reference to the new [`Color`](#color) object or a reference to the current [`Color`](#color) if
     `in_place` is `#!py3 True`.
+///
+
+## `#!py Color.layer` {#layer}
+
+```py
+@classmethod
+def layer(
+    cls,
+    colors: Sequence[ColorInput],
+    *,
+    blend: str | bool = True,
+    operator: str | bool = True,
+    space: str | None = None,
+    out_space: str | None = None
+) -> Color:
+```
+
+/// define
+Description
+
+-   Layer colors on time of each other and apply compositing which consists of a [blend mode](../compositing.md#blend-modes)
+    and a [Porter Duff operator](../compositing.md#compositing-operators) for alpha compositing. Colors are provided in
+    a list where the left most color is treated as the top most color and the right most color is treated as the bottom
+    most color. Colors will be composited in the `srgb` color space unless otherwise specified.
+
+    Compositing should generally be applied in RGB-ish color spaces (sRGB, Display P3, A98 RGB, etc.). The algorithm is
+    designed only for RGB-ish colors. Non-RGB-ish colors are likely to provide nonsense results.
+
+    Supported blend modes are:
+
+    Blend Modes  | &nbsp;       | &nbsp;       | &nbsp;
+    ------------ | ------------ | ------------ | ------------
+    `normal`     | `multiply`   | `darken`     | `lighten`
+    `burn`       | `dodge`      | `screen`     | `overlay`
+    `hard-light` | `exclusion`  | `difference` | `soft-light`
+    `hue`        | `saturation` | `luminosity` | `color`
+    `color`      | `hue`        | `saturation` | `luminosity`
+
+    Supported Port Duff operators are:
+
+    Operators          | &nbsp;        | &nbsp;             | &nbsp;
+    ------------------ | ------------- | ------------------ | ------------
+    `clear`            | `copy`        | `destination`      |`source-over`
+    `destination-over` | `source-in`   | `destination-in`   | `source-out`
+    `destination-out`  | `source-atop` | `destination-atop` | `xor`
+    `lighter`          | &nbsp;        | &nbsp;             | &nbsp;
+
+Parameters
+
+- 
+    Parameters  | Defaults       | Description
+    ----------- | -------------- | -----------
+    `colors`    |                | A sequence of color strings, [`Color`](#color) objects, and/or dictionaries representing a color.
+    `blend`     | `#!py3 None`   | A blend mode to use to use when compositing. Values should be a string specifying the name of the blend mode to use. If `#!py None`, [`normal`](#normal) will be used. If `#!py False`, blending will be skipped.
+    `operator`  | `#!py3 None`   | A Porter Duff operator to use for alpha compositing. Values should be a string specifying the name of the operator to use. If `#!py None`, [`source-over`](#source-over) will be used. If `#!py False`, alpha compositing will be skipped.
+    `space`     | `#!py3 None`   | A color space to perform the overlay in. If `#!py None`, the base color's space will be used.
+    `out_space` | `#!py None`    | Color space that the new color should be in. If `#!py None`, the return color will be in the same color space as specified by `space`.
+
+Return
+
+-   Returns a reference to the new [`Color`](#color) object.
 ///
 
 ## `#!py Color.clip` {#clip}

--- a/docs/src/markdown/compositing.md
+++ b/docs/src/markdown/compositing.md
@@ -1,11 +1,23 @@
 # Compositing and Blending
 
-Alpha compositing and blending are tied together under the umbrella of compositing. Each is just an aspect of
-the overall compositing of colors. Blend is run first, followed by alpha compositing.
+Alpha compositing and blending are tied together under the umbrella of compositing. Each is just an aspect of the
+overall compositing of colors. Compositing simply controls how colors are resolved when they are layered on top of each
+other.
 
 ColorAide implements both alpha compositing and blending as described in the [Compositing and Blending Level 1][compositing-level-1]
-specification. Alpha composting is based on [Porter Duff compositing][porter-duff]. By default, the `compose` method
-uses the `normal` blend mode and the `source-over` Porter Duff operator.
+specification. Alpha composting is based on [Porter Duff compositing][porter-duff]. By default, the `layer` method is
+used to layer colors on top of each other applying the appropriate compositing, using the `normal` blend mode and the
+`source-over` Porter Duff operator by default.
+
+/// warning | Deprecated 4.0
+`compose` method was deprecated in favor of the new `layer` method.
+///
+
+
+/// new | New in 4.0
+A new `layer` method was added which uses a more intuitive name and aligns with how how multiple colors are handled in
+other similar APIs such as `average()`, `interpolate()`, etc.
+///
 
 ## Blending
 
@@ -29,16 +41,17 @@ But there are many blend modes that could be used, all of which yield different 
   <span class="circle circle-2"></span>
 </span>
 
-When composing, the blend mode can be controlled separately in ColorAide. Here, we again use the `multiply` example
-and replicate it in ColorAide. To apply blending in ColorAide, simply call `compose` with a backdrop color, and the
-calling color will be used as the source.
+When layering colors, the blend mode can be controlled separately in ColorAide. Below, we use the `multiply` example and
+replicate it in ColorAide. To apply various blend modes in ColorAide, simply call `layer` with a list of colors.
+Colors will be layered on top of each other where the left most color is on top and the right most color will be on the
+bottom.
 
 /// tab | Display P3
 ```py play
 c1 = Color('#07c7ed')
 c2 = Color('#fc3d99')
 c1, c2
-c1.compose(c2, blend='multiply', space="display-p3")
+Color.layer([c1, c2], blend='multiply', space="display-p3")
 ```
 ///
 
@@ -47,15 +60,15 @@ c1.compose(c2, blend='multiply', space="display-p3")
 c1 = Color('#07c7ed')
 c2 = Color('#fc3d99')
 c1, c2
-c1.compose(c2, blend='multiply', space="srgb")
+Color.layer([c1, c2], blend='multiply', space="srgb")
 ```
 ///
 
 /// tip
-`compose()` can output the results in any color space you need by setting `out_space`.
+`layer()` can output the results in any color space you need by setting `out_space`.
 
 ```py play
-Color('#07c7ed').compose(Color('#fc3d99'), blend='multiply', space='srgb', out_space='hsl')
+Color.layer(['#07c7ed', '#fc3d99'], blend='multiply', space='srgb', out_space='hsl')
 ```
 ///
 
@@ -64,9 +77,8 @@ As some browsers apply compositing based on the display's current color space, w
 and Display P3 so that the examples can be compared on different displays. Which of the above matches your browser?
 ///
 
-ColorAide allows you to blend a source over multiple backdrops quite easily as well. Simply send in a list, and the
-colors will be blended from right to left with the right most color being on the bottom of the stack, and the base color
-being used as the source (on the very top).
+ColorAide allows for layering any number of colors as well, simply list of as many colors as you like ordered from left
+to right, left being the top most color.
 
 <span class="isolate blend-multiply">
   <span class="circle circle-1"></span>
@@ -80,7 +92,7 @@ c1 = Color('#07c7ed')
 c2 = Color('#fc3d99')
 c3 = Color('#f5d311')
 c1, c2, c3
-c1.compose([c2, c3], blend='multiply', space="display-p3")
+Color.layer([c1, c2, c3], blend='multiply', space="display-p3")
 ```
 ///
 
@@ -90,12 +102,12 @@ c1 = Color('#07c7ed')
 c2 = Color('#fc3d99')
 c3 = Color('#f5d311')
 c1, c2, c3
-c1.compose([c2, c3], blend='multiply', space="srgb")
+Color.layer([c1, c2, c3], blend='multiply', space="srgb")
 ```
 ///
 
-Lastly, if for any reason, it is desired to compose with blending disabled (e.g. just run alpha compositing), then you
-can simply set `blend` to `#!py3 False`.
+Lastly, if for any reason, it is desired to layer the colors with the blending step disabled (e.g. just run alpha
+compositing), then you can simply set `blend` to `#!py3 False`.
 
 [`multiply`](#multiply) is just one of many blend modes that are offered in ColorAide, check out
 [Blend Modes](#blend-modes) to learn about other blend modes.
@@ -119,17 +131,17 @@ semi-transparent layers on top of each other.
   <span class="circle circle-2" style="opacity: 0.5"></span>
 </span>
 
-Given two colors, ColorAide can replicate this behavior and determine the resultant color by applying compositing. We
-will use the demonstration above and replicate the result in the example below. Below we set the source color to
-`#!color Color('#07c7ed').set('alpha', 0.5)` and the backdrop color to `#!color #fc3d99` and run it through the
-`compose` method. It should be noted that the default blend mode of `normal` is used in conjunction by default.
+Given two colors layered on top of each other, ColorAide can replicate this behavior and determine the resultant color
+by applying alpha compositing. We will use the demonstration above and replicate the result in the example below by
+setting the source color to `#!color Color('#07c7ed').set('alpha', 0.5)` and the backdrop color to `#!color #fc3d99` and
+then running it through the `layer` method.
 
 /// tab | Display P3
 ```py play
 c1 = Color('#07c7ed').set('alpha', 0.5)
 c2 = Color('#fc3d99')
 c1, c2
-c1.compose(c2, space="display-p3")
+Color.layer([c1, c2], space="display-p3")
 ```
 ///
 
@@ -138,7 +150,7 @@ c1.compose(c2, space="display-p3")
 c1 = Color('#07c7ed').set('alpha', 0.5)
 c2 = Color('#fc3d99')
 c1, c2
-c1.compose(c2, space="srgb")
+Color.layer([c1, c2], space="srgb")
 ```
 ///
 
@@ -162,7 +174,7 @@ backdrop is fully opaque, we just get the backdrop color unaltered.
 c1 = Color('#07c7ed').set('alpha', 0.5)
 c2 = Color('#fc3d99')
 c1, c2
-c1.compose(c2, operator='destination-over', space="display-p3")
+Color.layer([c1, c2], operator='destination-over', space="display-p3")
 ```
 ///
 
@@ -171,13 +183,13 @@ c1.compose(c2, operator='destination-over', space="display-p3")
 c1 = Color('#07c7ed').set('alpha', 0.5)
 c2 = Color('#fc3d99')
 c1, c2
-c1.compose(c2, operator='destination-over', space="srgb")
+Color.layer([c1, c2], operator='destination-over', space="srgb")
 ```
 ///
 
-You can also apply alpha compositing to multiple layers at once. Simply send in a list of colors as the backdrop, and
-the colors will be composed from right to left with the right most color being on the bottom of the stack and the base
-color (the source) being on the very top.
+You can also apply alpha compositing to multiple layers at once. Simply send in a list of colors of any length, and the
+colors will be layered on top of each other from right to left with the right most color being on the bottom of the
+stack and the left color (the source) being on the very top.
 
 Here we are using the normal blend mode and 50% transparency on all the circles with an opaque white background. We will
 calculate the center color where all three layers overlap.
@@ -197,7 +209,7 @@ c2 = Color('#fc3d99').set('alpha', 0.5)
 c3 = Color('#f5d311').set('alpha', 0.5)
 bg = Color('white')
 c1, c2, c3, bg
-c1.compose([c2, c3, bg], blend='normal', space="display-p3")
+Color.layer([c1, c2, c3, bg], blend='normal', space="display-p3")
 ```
 ///
 
@@ -208,18 +220,18 @@ c2 = Color('#fc3d99').set('alpha', 0.5)
 c3 = Color('#f5d311').set('alpha', 0.5)
 bg = Color('white')
 c1, c2, c3, bg
-c1.compose([c2, c3, bg], blend='normal', space="srgb")
+Color.layer([c1, c2, c3, bg], blend='normal', space="srgb")
 ```
 ///
 
-Lastly, if for any reason, it is desired to run compose with alpha compositing disabled (e.g. just run blending),
-then you can simply set `operator` to `#!py3 False`.
+Lastly, if for any reason, it is desired to layer colors with alpha compositing disabled (e.g. just run blending), then
+you can simply set `operator` to `#!py3 False`.
 
 Check out [Compositing Operators](#compositing-operators) to learn about the many variations that are supported.
 
 ## Complex Compositing
 
-We've covered alpha compositing and blending and have demonstrated their use with simple two color examples and 
+We've covered alpha compositing and blending and have demonstrated their use with simple two color examples and
 multi-layered examples, but what about different blend modes mixed with alpha compositing?
 
 In this example, we will consider three circles, each with a unique color: `#!color #07c7ed`, `#!color #fc3d99`, and
@@ -246,16 +258,16 @@ c1 = Color('#07c7ed').set('alpha', 0.5)
 c2 = Color('#fc3d99').set('alpha', 0.5)
 c3 = Color('#f5d311').set('alpha', 0.5)
 
-cw2 = c2.compose('white', blend='normal', space='display-p3')
-cw3 = c3.compose('white', blend='normal', space='display-p3')
+cw2 = Color.layer([c2, 'white'], blend='normal', space='display-p3')
+cw3 = Color.layer([c3, 'white'], blend='normal', space='display-p3')
 
-r1 = c2.compose(cw3, blend='multiply', space='display-p3')
-r2 = c1.compose(cw2, blend='multiply', space='display-p3')
-r3 = c1.compose(cw3, blend='multiply', space='display-p3')
+r1 = Color.layer([c2, cw3], blend='multiply', space='display-p3')
+r2 = Color.layer([c1, cw2], blend='multiply', space='display-p3')
+r3 = Color.layer([c1, cw3], blend='multiply', space='display-p3')
 
 r1, r2, r3
 
-c1.compose([c2, cw3], blend='multiply', space='display-p3')
+Color.layer([c1, c2, cw3], blend='multiply', space='display-p3')
 ```
 ///
 
@@ -265,16 +277,16 @@ c1 = Color('#07c7ed').set('alpha', 0.5)
 c2 = Color('#fc3d99').set('alpha', 0.5)
 c3 = Color('#f5d311').set('alpha', 0.5)
 
-cw2 = c2.compose('white', blend='normal', space='srgb')
-cw3 = c3.compose('white', blend='normal', space='srgb')
+cw2 = Color.layer([c2, 'white'], blend='normal', space='srgb')
+cw3 = Color.layer([c3, 'white'], blend='normal', space='srgb')
 
-r1 = c2.compose(cw3, blend='multiply', space='srgb')
-r2 = c1.compose(cw2, blend='multiply', space='srgb')
-r3 = c1.compose(cw3, blend='multiply', space='srgb')
+r1 = Color.layer([c2, cw3], blend='multiply', space='srgb')
+r2 = Color.layer([c1, cw2], blend='multiply', space='srgb')
+r3 = Color.layer([c1, cw3], blend='multiply', space='srgb')
 
 r1, r2, r3
 
-c1.compose([c2, cw3], blend='multiply', space='srgb')
+Color.layer([c1, c2, cw3], blend='multiply', space='srgb')
 ```
 ///
 

--- a/docs/src/markdown/compositing.md
+++ b/docs/src/markdown/compositing.md
@@ -10,7 +10,8 @@ used to layer colors on top of each other applying the appropriate compositing, 
 `source-over` Porter Duff operator by default.
 
 /// warning | Deprecated 4.0
-`compose` method was deprecated in favor of the new `layer` method.
+[`compose`](./api/index.md#compose) method was deprecated in favor of the new `layer` method and will be removed at some
+future time.
 ///
 
 

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -11,13 +11,13 @@ class TestCompositing(util.ColorAsserts, unittest.TestCase):
         """Test that we can disable either blend or alpha compositing."""
 
         c1 = Color('#07c7ed').set('alpha', 0.5).compose('#fc3d99', blend='multiply', operator=False, space="srgb")
-        c2 = c1.compose('#fc3d99', blend=False, space="srgb")
+        c2 = Color.layer([c1, '#fc3d99'], blend=False, space="srgb")
         self.assertColorEqual(
-            Color('#07c7ed').set('alpha', 0.5).compose('#fc3d99', blend='multiply', space="srgb"),
+            Color.layer([Color('#07c7ed').set('alpha', 0.5), '#fc3d99'], blend='multiply', space="srgb"),
             c2
         )
         self.assertColorEqual(
-            Color('#07c7ed').set('alpha', 0.5).compose('#fc3d99', blend=False, operator=False, space="srgb"),
+            Color.layer([Color('#07c7ed').set('alpha', 0.5), '#fc3d99'], blend=False, operator=False, space="srgb"),
             Color('#07c7ed').set('alpha', 0.5)
         )
 
@@ -26,8 +26,8 @@ class TestCompositing(util.ColorAsserts, unittest.TestCase):
 
         c1 = Color('blue').set('alpha', 0.5)
         c2 = Color('yellow')
-        c3 = c1.compose(c2)
-        c4 = c1.compose(c2, operator='source-over')
+        c3 = Color.layer([c1, c2])
+        c4 = Color.layer([c1, c2], operator='source-over')
         self.assertEqual(c3, c4)
 
     def test_compose(self):
@@ -35,105 +35,101 @@ class TestCompositing(util.ColorAsserts, unittest.TestCase):
 
         c1 = Color('blue').set('alpha', 0.5)
         c2 = Color('yellow')
-        c3 = c1.compose(c2)
+        c3 = Color.layer([c1, c2])
         self.assertTrue(c1 is not c3)
-        self.assertEqual(c1.compose(c2), Color('color(srgb 0.5 0.5 0.5)'))
+        self.assertEqual(Color.layer([c1, c2]), Color('color(srgb 0.5 0.5 0.5)'))
 
     def test_compose_dict(self):
         """Test compositing with a mapping."""
 
         c1 = Color('blue').set('alpha', 0.5)
         self.assertEqual(
-            c1.compose("yellow"),
-            c1.compose({"space": "srgb", "coords": [1, 1, 0]})
+            Color.layer([c1, "yellow"]),
+            Color.layer([c1, {"space": "srgb", "coords": [1, 1, 0]}])
         )
 
     def test_compose_blend_multi(self):
         """Test compose blend with multiple colors."""
 
         self.assertColorEqual(
-            Color('#07c7ed').compose(['#fc3d99', '#f5d311'], blend='multiply', space="srgb"),
+            Color.layer([Color('#07c7ed'), '#fc3d99', '#f5d311'], blend='multiply', space="srgb"),
             Color('rgb(6.6464 39.39 9.48)')
         )
 
     def test_compose_alpha_multi(self):
-        """Test compose alpha compositing with multiple colors."""
+        """Test layer alpha compositing with multiple colors."""
 
         self.assertColorEqual(
-            Color('#07c7ed').set('alpha', 0.5).compose(
-                [Color('#fc3d99').set('alpha', 0.5), Color('#f5d311').set('alpha', 0.5), 'white'],
+            Color.layer(
+                [
+                    Color('#07c7ed').set('alpha', 0.5),
+                    Color('#fc3d99').set('alpha', 0.5),
+                    Color('#f5d311').set('alpha', 0.5),
+                    'white'
+                ],
                 blend='normal',
                 space="srgb"
             ),
             Color('rgb(129 173 190.75)')
         )
 
-    def test_compose_empty_list(self):
-        """Test compose with empty list."""
+    def test_compose_only_one(self):
+        """Test layer with only one color."""
 
-        self.assertColorEqual(Color('green').compose([]), Color('green'))
+        self.assertColorEqual(Color.layer(['green']), Color('green'))
 
     def test_compose_bad_operator(self):
-        """Test compose bad operator."""
+        """Test layer with bad operator."""
 
         with self.assertRaises(ValueError):
-            Color('red').compose('blue', operator='bad')
+            Color.layer(['red', 'blue'], operator='bad')
 
     def test_compose_nan(self):
-        """Test compose with `NaN` values."""
+        """Test layer with `NaN` values."""
 
         self.assertColorEqual(
-            Color('srgb', [NaN, 0.75, 0.75], 0.5).compose(Color('srgb', [1, 0.25, 0.25])),
+            Color.layer([Color('srgb', [NaN, 0.75, 0.75], 0.5), Color('srgb', [1, 0.25, 0.25])]),
             Color('rgb(127.5 127.5 127.5)')
         )
         self.assertColorEqual(
-            Color('srgb', [NaN, 0.75, 0.75], 0.5).compose(Color('srgb', [NaN, 0.25, 0.25])),
+            Color.layer([Color('srgb', [NaN, 0.75, 0.75], 0.5), Color('srgb', [NaN, 0.25, 0.25])]),
             Color('rgb(0 127.5 127.5)')
         )
         self.assertColorEqual(
-            Color('srgb', [0.2, 0.75, 0.75], 0.5).compose(Color('srgb', [NaN, 0.25, 0.25])),
+            Color.layer([Color('srgb', [0.2, 0.75, 0.75], 0.5), Color('srgb', [NaN, 0.25, 0.25])]),
             Color('rgb(25.5 127.5 127.5)')
         )
 
     def test_compose_bad_space(self):
-        """Test compose logic."""
+        """Test layer with bad space."""
 
         c1 = Color('blue').set('alpha', 0.5)
         c2 = Color('yellow')
         with self.assertRaises(KeyError):
-            c1.compose(c2, space="bad")
+            Color.layer([c1, c2], space="bad")
 
     def test_compose_no_alpha(self):
-        """Test compose logic when color has no alpha."""
+        """Test layer logic when color has no alpha."""
 
         c1 = Color('blue')
         c2 = Color('yellow')
-        c3 = c1.compose(c2)
+        c3 = Color.layer([c1, c2])
         self.assertTrue(c1 is not c3)
         self.assertEqual(c1.compose(c2), c1)
 
     def test_compose_nan_alpha(self):
-        """Test compose logic with alpha as `NaN`."""
+        """Test layer logic with alpha as `NaN`."""
 
         c1 = Color('blue').set('alpha', NaN)
         c2 = Color('yellow')
-        c3 = c1.compose(c2)
+        c3 = Color.layer([c1, c2])
         self.assertTrue(c1 is not c3)
         self.assertEqual(c3, Color('color(srgb 1 1 0 / 1)'))
 
-    def test_compose_in_place(self):
-        """Test compose logic."""
-
-        c1 = Color('blue').set('alpha', 0.5)
-        c2 = Color('yellow')
-        c3 = c1.compose(c2, in_place=True)
-        self.assertTrue(c1 is c3)
-        self.assertEqual(c1, Color('color(srgb 0.5 0.5 0.5)'))
-
     def test_compose_cyl(self):
-        """Test compose logic."""
+        """Test layer logic with non-RGB space."""
 
         c1 = Color('blue').set('alpha', 0.5)
         c2 = Color('yellow')
         with self.assertRaises(ValueError):
-            c1.compose(c2, space="hsl")
+            Color.layer([c1, c2], space="hsl")

--- a/tools/compose_imgs.py
+++ b/tools/compose_imgs.py
@@ -48,13 +48,19 @@ def printt(t):
 def apply_compositing(background, blend, operator, pixels, fit, space):
     """Apply compositing."""
 
-    color = Color('srgb', [x / 255 for x in pixels[0][:-1]], pixels[0][3] / 255)
-    backdrops = [Color('srgb', [x / 255 for x in p[:3]], p[3] / 255) for p in pixels[1:]]
-    color.compose(backdrops, blend=blend, operator=operator, in_place=True, space=space, out_space='srgb').clip()
+    result = Color.layer(
+        [Color('srgb', [x / 255 for x in p[:-1]], p[-1] / 255) for p in pixels],
+        blend=blend,
+        operator=operator,
+        space=space,
+        out_space='srgb'
+    ).clip()
+
     # Overlay first layer on background color in isolation
     if background != 'transparent':
-        color.compose(background, in_place=True).clip()
-    return tuple(int(x * 255) for x in color.fit(method=fit)[:4])
+        result = Color.layer([result, background]).clip()
+
+    return tuple(int(x * 255) for x in result.fit(method=fit)[:4])
 
 
 def process_image(imgs, bg, output, blend, porter_duff, fit, space):


### PR DESCRIPTION
Add layer() which has a more intuitive name than compose() and aligns with multi-color handling similar to other API methods that handle multi-color, like interpolate(), average(), steps(), etc.