### PR TITLE
Restrict correction algorithm to produce sane results in extreme cases

### DIFF
--- a/coloraide/gamut/fit_raytrace.py
+++ b/coloraide/gamut/fit_raytrace.py
@@ -35,6 +35,11 @@ def project_onto(a: Vector, b: Vector, o: Vector) -> Vector:
     vec_ob = [b[0] - ox, b[1] - oy, b[2] - oz]
     # Project `vec_oa` onto `vec_ob` and convert back to a point
     r = alg.vdot(vec_oa, vec_ob) / alg.vdot(vec_ob, vec_ob)
+    # Some spaces may be project something that exceeds the range of our target vector.
+    if r > 1.0:
+        r = 1.0
+    elif r < 0.0:  # pragma: no cover
+        r = 0.0
     return [vec_ob[0] * r + ox, vec_ob[1] * r + oy, vec_ob[2] * r + oz]
 
 
@@ -275,8 +280,8 @@ class RayTrace(Fit):
             # to the new corrected color finding the intersection again.
             mapcolor.convert(space, in_place=True)
 
-            # Interpolation path
             if adaptive:
+                # Interpolation path
                 start = [light, *ab]
                 end = [alight, 0.0, 0.0]
 
@@ -323,7 +328,7 @@ class RayTrace(Fit):
                 # Adjust anchor point closer to surface to improve results for some spaces.
                 # Don't move point too close to the surface to avoid corner cases with some spaces.
                 if i and all(low < x < high for x in coords):
-                    anchor = mapcolor[:-1]
+                    anchor = coords
 
                 # Update color with the intersection point on the RGB surface.
                 if intersection:

--- a/tests/test_gamut.py
+++ b/tests/test_gamut.py
@@ -298,6 +298,16 @@ class TestRayTrace(util.ColorAsserts, unittest.TestCase):
             Color('color(display-p3 0.89593 0.90035 0.29412)')
         )
 
+    def test_edge_case_raytrace_adaptive_lightness_lch(self):
+        """Test edge case ray trace adaptive lightness."""
+
+        # Force projection out of range on high end.
+        options = {"method": 'raytrace', "pspace": 'lchuv', "adaptive": 0.5}
+        self.assertColorEqual(
+            Color('rec2020', [0, 0, 0.5]).fit('srgb', **options),
+            Color('color(rec2020 0.06611 0.06611 0.45269)')
+        )
+
     def test_sdr_extremes_low(self):
         """Test SDR extreme low case."""
 

--- a/tools/raytrace_test.py
+++ b/tools/raytrace_test.py
@@ -261,6 +261,8 @@ def simulate_raytrace_gamut_mapping(args):
         points.append(color.convert(space)[:-1])
         points.append(achromatic)
     else:
+        print('Initial:', mapcolor)
+        print('Anchor:', achroma.convert(pspace), '\n----')
         gamutcolor = mapcolor.convert(space)
 
         # Threshold for anchor adjustment
@@ -274,6 +276,7 @@ def simulate_raytrace_gamut_mapping(args):
         for i in range(4):
             if i:
                 gamutcolor.convert(pspace, in_place=True, norm=False)
+                print('Uncorrected:', gamutcolor)
 
                 if adaptive:
                     # Correct the point onto the desired interpolation path
@@ -290,6 +293,7 @@ def simulate_raytrace_gamut_mapping(args):
                             [light, *ab],
                             [alight, 0.0, 0.0]
                         )
+
                 else:
                     # Correct lightness and hue
                     gamutcolor[l] = alight
@@ -301,13 +305,15 @@ def simulate_raytrace_gamut_mapping(args):
                             hue
                         )
 
+                print('Corrected:', gamutcolor)
                 gamutcolor.convert(space, in_place=True)
+                print('Corrected RGB:', gamutcolor, '\n----')
 
             coords = gamutcolor[:-1]
             intersection = raytrace_box(achromatic, coords, bmax=bmax)
 
             if i and all(low < x < high for x in coords):
-                achromatic = gamutcolor[:-1]
+                achromatic = coords
 
             if intersection:
                 points.append(gamutcolor[:-1])
@@ -317,7 +323,9 @@ def simulate_raytrace_gamut_mapping(args):
                 continue
             break  # pragma: no cover
 
+        print('Final:', gamutcolor.convert(pspace, norm=False))
         color.update(space, [alg.clamp(x, 0.0, bmx) for x in gamutcolor[:-1]])
+        print('Clipped RGB:', color.convert(space))
 
     # If we have coerced a space to RGB, update the original
     if coerced:


### PR DESCRIPTION
When using ray trace and the adaptive lightness approach, Luv and its cylindrical counter part can produce chroma reduction curves that stress the algorithm in the dark blue region. This can yield yellows which make no sense.

Add a restriction in the correction code that projects the color onto the chroma reduction vector in the Lab model to restrict extreme results, outside the range of the vector, which can create colors outside the color space's ability to convert the color causing massive hue shifts.

Colors will still not be accurate, but they will be much closer to then intended target and be a more sane representation.