### PR TITLE
Optimized versions of basic math functions for length 3 arrays

### DIFF
--- a/coloraide/cat.py
+++ b/coloraide/cat.py
@@ -58,10 +58,10 @@ def calc_adaptation_matrices(
     http://www.brucelindbloom.com/index.html?Math.html
     """
 
-    src = alg.matmul(m, util.xy_to_xyz(w1), dims=alg.D2_D1)
-    dest = alg.matmul(m, util.xy_to_xyz(w2), dims=alg.D2_D1)
-    m2 = alg.diag(alg.divide(dest, src, dims=alg.D1))
-    adapt = alg.matmul(alg.solve(m, m2), m, dims=alg.D2)
+    src = alg.matmul_x3(m, util.xy_to_xyz(w1), dims=alg.D2_D1)
+    dest = alg.matmul_x3(m, util.xy_to_xyz(w2), dims=alg.D2_D1)
+    m2 = alg.diag(alg.divide_x3(dest, src, dims=alg.D1))
+    adapt = alg.matmul_x3(alg.solve(m, m2), m, dims=alg.D2)
 
     return adapt, alg.inv(adapt)
 
@@ -119,7 +119,7 @@ class VonKries(CAT):
 
         a, b = sorted([w1, w2])
         m, mi = self.get_adaptation_matrices(a, b)
-        return alg.matmul(mi if a != w1 else m, xyz, dims=alg.D2_D1)
+        return alg.matmul_x3(mi if a != w1 else m, xyz, dims=alg.D2_D1)
 
 
 class Bradford(VonKries):

--- a/coloraide/filters/cvd.py
+++ b/coloraide/filters/cvd.py
@@ -136,11 +136,11 @@ def brettel(color: Color, severity: float, wings: tuple[Matrix, Matrix, Vector])
     w1, w2, sep = wings
 
     # Convert to LMS
-    lms_c = alg.matmul(LRGB_TO_LMS, color[:-1], dims=alg.D2_D1)
+    lms_c = alg.matmul_x3(LRGB_TO_LMS, color[:-1], dims=alg.D2_D1)
 
     # Apply appropriate wing filter based on which side of the separator we are on.
     # Tritanopia filter and LMS to sRGB conversion are included in the same matrix.
-    coords = alg.matmul(w2 if alg.matmul(lms_c, sep) > 0 else w1, lms_c, dims=alg.D2_D1)
+    coords = alg.matmul_x3(w2 if alg.matmul_x3(lms_c, sep, dims=alg.D1) > 0 else w1, lms_c, dims=alg.D2_D1)
 
     if severity < 1:
         color[:-1] = [alg.lerp(a, b, severity) for a, b in zip(color[:-1], coords)]
@@ -164,7 +164,7 @@ def vienot(color: Color, severity: float, transform: Matrix) -> None:
     then we interpolate against the original color.
     """
 
-    coords = alg.matmul(transform, color[:-1], dims=alg.D2_D1)
+    coords = alg.matmul_x3(transform, color[:-1], dims=alg.D2_D1)
     if severity < 1:
         color[:-1] = [alg.lerp(c1, c2, severity) for c1, c2 in zip(color[:-1], coords)]
     else:
@@ -187,7 +187,7 @@ def machado(color: Color, severity: float, matrices: dict[int, Matrix]) -> None:
 
     # Filter the color according to the severity
     m1 = matrices[severity1]
-    coords = alg.matmul(m1, color[:-1], dims=alg.D2_D1)
+    coords = alg.matmul_x3(m1, color[:-1], dims=alg.D2_D1)
 
     # If severity was not exact, and it also isn't max severity,
     # let's calculate the next most severity and interpolate
@@ -204,7 +204,7 @@ def machado(color: Color, severity: float, matrices: dict[int, Matrix]) -> None:
         # but it ends up being faster just modifying the color on both the high
         # and low matrix and interpolating the color than interpolating the matrix
         # and then applying it to the color. The results are identical as well.
-        coords2 = alg.matmul(m2, color[:-1], dims=alg.D2_D1)
+        coords2 = alg.matmul_x3(m2, color[:-1], dims=alg.D2_D1)
         coords = [alg.lerp(c1, c2, weight) for c1, c2 in zip(coords, coords2)]
 
     # Return the altered color

--- a/coloraide/filters/w3c_filter_effects.py
+++ b/coloraide/filters/w3c_filter_effects.py
@@ -36,7 +36,7 @@ class Sepia(Filter):
             [0.272 - 0.272 * amount, 0.534 - 0.534 * amount, 0.131 + 0.869 * amount]
         ]
 
-        color[:-1] = alg.matmul(m, color[:-1], dims=alg.D2_D1)
+        color[:-1] = alg.matmul_x3(m, color[:-1], dims=alg.D2_D1)
 
 
 class Grayscale(Filter):
@@ -56,7 +56,7 @@ class Grayscale(Filter):
             [0.2126 - 0.2126 * amount, 0.7152 - 0.7152 * amount, 0.0722 + 0.9278 * amount]
         ]
 
-        color[:-1] = alg.matmul(m, color[:-1], dims=alg.D2_D1)
+        color[:-1] = alg.matmul_x3(m, color[:-1], dims=alg.D2_D1)
 
 
 class Saturate(Filter):
@@ -76,7 +76,7 @@ class Saturate(Filter):
             [0.213 - 0.213 * amount, 0.715 - 0.715 * amount, 0.072 + 0.928 * amount]
         ]
 
-        color[:-1] = alg.matmul(m, color[:-1], dims=alg.D2_D1)
+        color[:-1] = alg.matmul_x3(m, color[:-1], dims=alg.D2_D1)
 
 
 class Invert(Filter):
@@ -153,4 +153,4 @@ class HueRotate(Filter):
             [0.213 - cos * 0.213 - sin * 0.787, 0.715 - cos * 0.715 + sin * 0.715, 0.072 + cos * 0.928 + sin * 0.072]
         ]
 
-        color[:-1] = alg.matmul(m, color[:-1], dims=alg.D2_D1)
+        color[:-1] = alg.matmul_x3(m, color[:-1], dims=alg.D2_D1)

--- a/coloraide/gamut/fit_raytrace.py
+++ b/coloraide/gamut/fit_raytrace.py
@@ -34,7 +34,7 @@ def project_onto(a: Vector, b: Vector, o: Vector) -> Vector:
     vec_oa = [a[0] - ox, a[1] - oy, a[2] - oz]
     vec_ob = [b[0] - ox, b[1] - oy, b[2] - oz]
     # Project `vec_oa` onto `vec_ob` and convert back to a point
-    r = alg.vdot(vec_oa, vec_ob) / alg.vdot(vec_ob, vec_ob)
+    r = alg.matmul_x3(vec_oa, vec_ob, dims=alg.D1) / alg.matmul_x3(vec_ob, vec_ob, dims=alg.D1)
     # Some spaces may project something that exceeds the range of our target vector.
     if r > 1.0:
         r = 1.0

--- a/coloraide/spaces/a98_rgb_linear.py
+++ b/coloraide/spaces/a98_rgb_linear.py
@@ -27,13 +27,13 @@ def lin_a98rgb_to_xyz(rgb: Vector) -> Vector:
     https://www.adobe.com/digitalimag/pdfs/AdobeRGB1998.pdf
     """
 
-    return alg.matmul(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
+    return alg.matmul_x3(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
 
 
 def xyz_to_lin_a98rgb(xyz: Vector) -> Vector:
     """Convert XYZ to linear-light a98-rgb."""
 
-    return alg.matmul(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
+    return alg.matmul_x3(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
 
 
 class A98RGBLinear(sRGBLinear):

--- a/coloraide/spaces/aces2065_1.py
+++ b/coloraide/spaces/aces2065_1.py
@@ -28,13 +28,13 @@ MAX = 1.0
 def aces_to_xyz(aces: Vector) -> Vector:
     """Convert ACEScc to XYZ."""
 
-    return alg.matmul(AP0_TO_XYZ, aces, dims=alg.D2_D1)
+    return alg.matmul_x3(AP0_TO_XYZ, aces, dims=alg.D2_D1)
 
 
 def xyz_to_aces(xyz: Vector) -> Vector:
     """Convert XYZ to ACEScc."""
 
-    return alg.matmul(XYZ_TO_AP0, xyz, dims=alg.D2_D1)
+    return alg.matmul_x3(XYZ_TO_AP0, xyz, dims=alg.D2_D1)
 
 
 class ACES20651(sRGBLinear):

--- a/coloraide/spaces/acescg.py
+++ b/coloraide/spaces/acescg.py
@@ -25,13 +25,13 @@ XYZ_TO_AP1 = [
 def acescg_to_xyz(acescg: Vector) -> Vector:
     """Convert ACEScc to XYZ."""
 
-    return alg.matmul(AP1_TO_XYZ, acescg, dims=alg.D2_D1)
+    return alg.matmul_x3(AP1_TO_XYZ, acescg, dims=alg.D2_D1)
 
 
 def xyz_to_acescg(xyz: Vector) -> Vector:
     """Convert XYZ to ACEScc."""
 
-    return alg.matmul(XYZ_TO_AP1, xyz, dims=alg.D2_D1)
+    return alg.matmul_x3(XYZ_TO_AP1, xyz, dims=alg.D2_D1)
 
 
 class ACEScg(sRGBLinear):

--- a/coloraide/spaces/cam16_jmh.py
+++ b/coloraide/spaces/cam16_jmh.py
@@ -159,7 +159,7 @@ class Environment:
         yw = xyz_w[1]
 
         # Cone response for reference white
-        rgb_w = alg.matmul(M16, xyz_w, dims=alg.D2_D1)
+        rgb_w = alg.matmul_x3(M16, xyz_w, dims=alg.D2_D1)
 
         # Surround: dark, dim, and average
         f, self.c, self.nc = SURROUND[self.surround]
@@ -182,7 +182,7 @@ class Environment:
         self.d_rgb_inv = [1 / coord for coord in self.d_rgb]
 
         # Achromatic response
-        rgb_cw = alg.multiply(rgb_w, self.d_rgb, dims=alg.D1)
+        rgb_cw = alg.multiply_x3(rgb_w, self.d_rgb, dims=alg.D1)
         rgb_aw = adapt(rgb_cw, self.fl)
         self.a_w = self.nbb * (2 * rgb_aw[0] + rgb_aw[1] + 0.05 * rgb_aw[2])
 
@@ -266,8 +266,8 @@ def cam16_to_xyz_d65(
     b = r * sin_h
 
     # Calculate back from cone response to XYZ
-    rgb_c = unadapt(alg.multiply(alg.matmul(M1, [p2, a, b], dims=alg.D2_D1), 1 / 1403, dims=alg.D1_SC), env.fl)
-    return util.scale1(alg.matmul(MI6_INV, alg.multiply(rgb_c, env.d_rgb_inv, dims=alg.D1), dims=alg.D2_D1))
+    rgb_c = unadapt(alg.multiply_x3(alg.matmul_x3(M1, [p2, a, b], dims=alg.D2_D1), 1 / 1403, dims=alg.D1_SC), env.fl)
+    return util.scale1(alg.matmul_x3(MI6_INV, alg.multiply_x3(rgb_c, env.d_rgb_inv, dims=alg.D1), dims=alg.D2_D1))
 
 
 def xyz_d65_to_cam16(xyzd65: Vector, env: Environment, calc_hue_quadrature: bool = False) -> Vector:
@@ -275,8 +275,8 @@ def xyz_d65_to_cam16(xyzd65: Vector, env: Environment, calc_hue_quadrature: bool
 
     # Cone response
     rgb_a = adapt(
-        alg.multiply(
-            alg.matmul(M16, util.scale100(xyzd65), dims=alg.D2_D1),
+        alg.multiply_x3(
+            alg.matmul_x3(M16, util.scale100(xyzd65), dims=alg.D2_D1),
             env.d_rgb,
             dims=alg.D1
         ),

--- a/coloraide/spaces/display_p3_linear.py
+++ b/coloraide/spaces/display_p3_linear.py
@@ -25,13 +25,13 @@ def lin_p3_to_xyz(rgb: Vector) -> Vector:
     """
 
     # 0 was computed as -3.972075516933488e-17
-    return alg.matmul(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
+    return alg.matmul_x3(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
 
 
 def xyz_to_lin_p3(xyz: Vector) -> Vector:
     """Convert XYZ to linear-light P3."""
 
-    return alg.matmul(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
+    return alg.matmul_x3(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
 
 
 class DisplayP3Linear(sRGBLinear):

--- a/coloraide/spaces/hunter_lab.py
+++ b/coloraide/spaces/hunter_lab.py
@@ -23,10 +23,10 @@ CKB = 70.0
 def xyz_to_hlab(xyz: Vector, white: VectorLike) -> Vector:
     """Convert XYZ to Hunter Lab."""
 
-    xn, yn, zn = alg.multiply(util.xy_to_xyz(white), 100, dims=alg.D1_SC)
+    xn, yn, zn = alg.multiply_x3(util.xy_to_xyz(white), 100, dims=alg.D1_SC)
     ka = CKA * alg.nth_root(xn / CXN, 2)
     kb = CKB * alg.nth_root(zn / CZN, 2)
-    x, y, z = alg.multiply(xyz, 100, dims=alg.D1_SC)
+    x, y, z = alg.multiply_x3(xyz, 100, dims=alg.D1_SC)
     l = alg.nth_root(y / yn, 2)
     a = b = 0.0
     if l != 0:
@@ -38,7 +38,7 @@ def xyz_to_hlab(xyz: Vector, white: VectorLike) -> Vector:
 def hlab_to_xyz(hlab: Vector, white: VectorLike) -> Vector:
     """Convert Hunter Lab to XYZ."""
 
-    xn, yn, zn = alg.multiply(util.xy_to_xyz(white), 100, dims=alg.D1_SC)
+    xn, yn, zn = alg.multiply_x3(util.xy_to_xyz(white), 100, dims=alg.D1_SC)
     ka = CKA * alg.nth_root(xn / CXN, 2)
     kb = CKB * alg.nth_root(zn / CZN, 2)
     l, a, b = hlab
@@ -46,7 +46,7 @@ def hlab_to_xyz(hlab: Vector, white: VectorLike) -> Vector:
     y = (l ** 2) * yn
     x = (((a * l) / ka) + (y / yn)) * xn
     z = (((b * l) / kb) - (y / yn)) * -zn
-    return alg.multiply([x, y, z], 0.01, dims=alg.D1_SC)
+    return alg.multiply_x3([x, y, z], 0.01, dims=alg.D1_SC)
 
 
 class HunterLab(Lab):

--- a/coloraide/spaces/ictcp.py
+++ b/coloraide/spaces/ictcp.py
@@ -57,13 +57,13 @@ def ictcp_to_xyz_d65(ictcp: Vector) -> Vector:
     """From ICtCp to XYZ."""
 
     # Convert to LMS prime
-    pqlms = alg.matmul(ictcp_to_lms_p_mi, ictcp, dims=alg.D2_D1)
+    pqlms = alg.matmul_x3(ictcp_to_lms_p_mi, ictcp, dims=alg.D2_D1)
 
     # Decode PQ LMS to LMS
     lms = util.pq_st2084_eotf(pqlms)
 
     # Convert back to absolute XYZ D65
-    absxyz = alg.matmul(lms_to_xyz_mi, lms, dims=alg.D2_D1)
+    absxyz = alg.matmul_x3(lms_to_xyz_mi, lms, dims=alg.D2_D1)
 
     # Convert back to normal XYZ D65
     return util.absxyz_to_xyz(absxyz, YW)
@@ -76,13 +76,13 @@ def xyz_d65_to_ictcp(xyzd65: Vector) -> Vector:
     absxyz = util.xyz_to_absxyz(xyzd65, YW)
 
     # Convert to LMS
-    lms = alg.matmul(xyz_to_lms_m, absxyz, dims=alg.D2_D1)
+    lms = alg.matmul_x3(xyz_to_lms_m, absxyz, dims=alg.D2_D1)
 
     # PQ encode the LMS
     pqlms = util.pq_st2084_oetf(lms)
 
     # Calculate Izazbz
-    return alg.matmul(lms_p_to_ictcp_m, pqlms, dims=alg.D2_D1)
+    return alg.matmul_x3(lms_p_to_ictcp_m, pqlms, dims=alg.D2_D1)
 
 
 class ICtCp(Lab):

--- a/coloraide/spaces/igpgtg.py
+++ b/coloraide/spaces/igpgtg.py
@@ -38,25 +38,25 @@ IGPGTG_TO_LMS = [
 def xyz_to_igpgtg(xyz: Vector) -> Vector:
     """XYZ to IgPgTg."""
 
-    lms_in = alg.matmul(XYZ_TO_LMS, xyz, dims=alg.D2_D1)
+    lms_in = alg.matmul_x3(XYZ_TO_LMS, xyz, dims=alg.D2_D1)
     lms = [
         alg.spow(lms_in[0] / 18.36, 0.427),
         alg.spow(lms_in[1] / 21.46, 0.427),
         alg.spow(lms_in[2] / 19435, 0.427)
     ]
-    return alg.matmul(LMS_TO_IGPGTG, lms, dims=alg.D2_D1)
+    return alg.matmul_x3(LMS_TO_IGPGTG, lms, dims=alg.D2_D1)
 
 
 def igpgtg_to_xyz(itp: Vector) -> Vector:
     """IgPgTg to XYZ."""
 
-    lms = alg.matmul(IGPGTG_TO_LMS, itp, dims=alg.D2_D1)
+    lms = alg.matmul_x3(IGPGTG_TO_LMS, itp, dims=alg.D2_D1)
     lms_in = [
         alg.nth_root(lms[0], 0.427) * 18.36,
         alg.nth_root(lms[1], 0.427) * 21.46,
         alg.nth_root(lms[2], 0.427) * 19435
     ]
-    return alg.matmul(LMS_TO_XYZ, lms_in, dims=alg.D2_D1)
+    return alg.matmul_x3(LMS_TO_XYZ, lms_in, dims=alg.D2_D1)
 
 
 class IgPgTg(IPT):

--- a/coloraide/spaces/ipt.py
+++ b/coloraide/spaces/ipt.py
@@ -39,15 +39,15 @@ IPT_TO_LMS_P = [
 def xyz_to_ipt(xyz: Vector) -> Vector:
     """XYZ to IPT."""
 
-    lms_p = [alg.spow(c, 0.43) for c in alg.matmul(XYZ_TO_LMS, xyz, dims=alg.D2_D1)]
-    return alg.matmul(LMS_P_TO_IPT, lms_p, dims=alg.D2_D1)
+    lms_p = [alg.spow(c, 0.43) for c in alg.matmul_x3(XYZ_TO_LMS, xyz, dims=alg.D2_D1)]
+    return alg.matmul_x3(LMS_P_TO_IPT, lms_p, dims=alg.D2_D1)
 
 
 def ipt_to_xyz(ipt: Vector) -> Vector:
     """IPT to XYZ."""
 
-    lms = [alg.nth_root(c, 0.43) for c in alg.matmul(IPT_TO_LMS_P, ipt, dims=alg.D2_D1)]
-    return alg.matmul(LMS_TO_XYZ, lms, dims=alg.D2_D1)
+    lms = [alg.nth_root(c, 0.43) for c in alg.matmul_x3(IPT_TO_LMS_P, ipt, dims=alg.D2_D1)]
+    return alg.matmul_x3(LMS_TO_XYZ, lms, dims=alg.D2_D1)
 
 
 class IPT(Lab):

--- a/coloraide/spaces/jzazbz.py
+++ b/coloraide/spaces/jzazbz.py
@@ -74,26 +74,26 @@ def xyz_d65_to_izazbz(xyz: Vector, lms_matrix: Matrix, m2: float) -> Vector:
     ym = (G * ya) - ((G - 1) * xa)
 
     # Convert to LMS
-    lms = alg.matmul(XYZ_TO_LMS, [xm, ym, za], dims=alg.D2_D1)
+    lms = alg.matmul_x3(XYZ_TO_LMS, [xm, ym, za], dims=alg.D2_D1)
 
     # PQ encode the LMS
     pqlms = util.pq_st2084_oetf(lms, m2=m2)
 
     # Calculate Izazbz
-    return alg.matmul(lms_matrix, pqlms, dims=alg.D2_D1)
+    return alg.matmul_x3(lms_matrix, pqlms, dims=alg.D2_D1)
 
 
 def izazbz_to_xyz_d65(izazbz: Vector, lms_matrix: Matrix, m2: float) -> Vector:
     """Izazbz to absolute XYZ."""
 
     # Convert to LMS prime
-    pqlms = alg.matmul(lms_matrix, izazbz, dims=alg.D2_D1)
+    pqlms = alg.matmul_x3(lms_matrix, izazbz, dims=alg.D2_D1)
 
     # Decode PQ LMS to LMS
     lms = util.pq_st2084_eotf(pqlms, m2=m2)
 
     # Convert back to absolute XYZ D65
-    xm, ym, za = alg.matmul(LMS_TO_XYZ, lms, dims=alg.D2_D1)
+    xm, ym, za = alg.matmul_x3(LMS_TO_XYZ, lms, dims=alg.D2_D1)
     xa = (xm + ((B - 1) * za)) / B
     ya = (ym + ((G - 1) * xa)) / G
 

--- a/coloraide/spaces/lab/__init__.py
+++ b/coloraide/spaces/lab/__init__.py
@@ -37,14 +37,14 @@ def lab_to_xyz(lab: Vector, white: VectorLike) -> Vector:
     ]
 
     # Compute XYZ by scaling `xyz` by reference `white`
-    return alg.multiply(xyz, white, dims=alg.D1)
+    return alg.multiply_x3(xyz, white, dims=alg.D1)
 
 
 def xyz_to_lab(xyz: Vector, white: VectorLike) -> Vector:
     """Convert XYZ to CIE Lab using the reference white."""
 
     # compute `xyz`, which is XYZ scaled relative to reference white
-    xyz = alg.divide(xyz, white, dims=alg.D1)
+    xyz = alg.divide_x3(xyz, white, dims=alg.D1)
     # Compute `fx`, `fy`, and `fz`
     fx, fy, fz = (alg.nth_root(i, 3) if i > EPSILON else (KAPPA * i + 16) / 116 for i in xyz)
 

--- a/coloraide/spaces/okhsl.py
+++ b/coloraide/spaces/okhsl.py
@@ -142,9 +142,9 @@ def oklab_to_linear_rgb(lab: Vector, lms_to_rgb: Matrix) -> Vector:
     that transform the LMS values to the linear RGB space.
     """
 
-    return alg.matmul(
+    return alg.matmul_x3(
         lms_to_rgb,
-        [c ** 3 for c in alg.matmul(OKLAB_TO_LMS3, lab, dims=alg.D2_D1)],
+        [c ** 3 for c in alg.matmul_x3(OKLAB_TO_LMS3, lab, dims=alg.D2_D1)],
         dims=alg.D2_D1
     )
 
@@ -240,23 +240,23 @@ def find_gamut_intersection(
         mdt2 = 6 * (m_dt ** 2) * m_
         sdt2 = 6 * (s_dt ** 2) * s_
 
-        r = alg.vdot(lms_to_rgb[0], [l, m, s]) - 1
-        r1 = alg.vdot(lms_to_rgb[0], [ldt, mdt, sdt])
-        r2 = alg.vdot(lms_to_rgb[0], [ldt2, mdt2, sdt2])
+        r = alg.matmul_x3(lms_to_rgb[0], [l, m, s], dims=alg.D1) - 1
+        r1 = alg.matmul_x3(lms_to_rgb[0], [ldt, mdt, sdt], dims=alg.D1)
+        r2 = alg.matmul_x3(lms_to_rgb[0], [ldt2, mdt2, sdt2], dims=alg.D1)
 
         u_r = r1 / (r1 * r1 - 0.5 * r * r2)
         t_r = -r * u_r
 
-        g = alg.vdot(lms_to_rgb[1], [l, m, s]) - 1
-        g1 = alg.vdot(lms_to_rgb[1], [ldt, mdt, sdt])
-        g2 = alg.vdot(lms_to_rgb[1], [ldt2, mdt2, sdt2])
+        g = alg.matmul_x3(lms_to_rgb[1], [l, m, s], dims=alg.D1) - 1
+        g1 = alg.matmul_x3(lms_to_rgb[1], [ldt, mdt, sdt], dims=alg.D1)
+        g2 = alg.matmul_x3(lms_to_rgb[1], [ldt2, mdt2, sdt2], dims=alg.D1)
 
         u_g = g1 / (g1 * g1 - 0.5 * g * g2)
         t_g = -g * u_g
 
-        b = alg.vdot(lms_to_rgb[2], [l, m, s]) - 1
-        b1 = alg.vdot(lms_to_rgb[2], [ldt, mdt, sdt])
-        b2 = alg.vdot(lms_to_rgb[2], [ldt2, mdt2, sdt2])
+        b = alg.matmul_x3(lms_to_rgb[2], [l, m, s], dims=alg.D1) - 1
+        b1 = alg.matmul_x3(lms_to_rgb[2], [ldt, mdt, sdt], dims=alg.D1)
+        b2 = alg.matmul_x3(lms_to_rgb[2], [ldt2, mdt2, sdt2], dims=alg.D1)
 
         u_b = b1 / (b1 * b1 - 0.5 * b * b2)
         t_b = -b * u_b

--- a/coloraide/spaces/oklab/__init__.py
+++ b/coloraide/spaces/oklab/__init__.py
@@ -64,9 +64,9 @@ LMS_TO_XYZD65 = [
 def oklab_to_xyz_d65(lab: Vector) -> Vector:
     """Convert from Oklab to XYZ D65."""
 
-    return alg.matmul(
+    return alg.matmul_x3(
         LMS_TO_XYZD65,
-        [c ** 3 for c in alg.matmul(OKLAB_TO_LMS3, lab, dims=alg.D2_D1)],
+        [c ** 3 for c in alg.matmul_x3(OKLAB_TO_LMS3, lab, dims=alg.D2_D1)],
         dims=alg.D2_D1
     )
 
@@ -74,9 +74,9 @@ def oklab_to_xyz_d65(lab: Vector) -> Vector:
 def xyz_d65_to_oklab(xyz: Vector) -> Vector:
     """XYZ D65 to Oklab."""
 
-    return alg.matmul(
+    return alg.matmul_x3(
         LMS3_TO_OKLAB,
-        [alg.nth_root(c, 3) for c in alg.matmul(XYZD65_TO_LMS, xyz, dims=alg.D2_D1)],
+        [alg.nth_root(c, 3) for c in alg.matmul_x3(XYZD65_TO_LMS, xyz, dims=alg.D2_D1)],
         dims=alg.D2_D1
     )
 

--- a/coloraide/spaces/orgb.py
+++ b/coloraide/spaces/orgb.py
@@ -26,13 +26,13 @@ def rotate(v: Vector, d: float) -> Vector:
     m = alg.identity(3)
     m[1][1:] = math.cos(d), -math.sin(d)
     m[2][1:] = math.sin(d), math.cos(d)
-    return alg.matmul(m, v, dims=alg.D2_D1)
+    return alg.matmul_x3(m, v, dims=alg.D2_D1)
 
 
 def srgb_to_orgb(rgb: Vector) -> Vector:
     """Convert sRGB to oRGB."""
 
-    lcc = alg.matmul(RGB_TO_LC1C2, rgb, dims=alg.D2_D1)
+    lcc = alg.matmul_x3(RGB_TO_LC1C2, rgb, dims=alg.D2_D1)
     theta = math.atan2(lcc[2], lcc[1])
     theta0 = theta
     atheta = abs(theta)
@@ -55,7 +55,7 @@ def orgb_to_srgb(lcc: Vector) -> Vector:
     elif (math.pi / 2) <= atheta0 <= math.pi:
         theta = math.copysign((math.pi / 3) + (4 / 3) * (atheta0 - math.pi / 2), theta0)
 
-    return alg.matmul(LC1C2_TO_RGB, rotate(lcc, theta - theta0), dims=alg.D2_D1)
+    return alg.matmul_x3(LC1C2_TO_RGB, rotate(lcc, theta - theta0), dims=alg.D2_D1)
 
 
 class oRGB(Lab):

--- a/coloraide/spaces/prophoto_rgb_linear.py
+++ b/coloraide/spaces/prophoto_rgb_linear.py
@@ -26,13 +26,13 @@ def lin_prophoto_to_xyz(rgb: Vector) -> Vector:
     http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
     """
 
-    return alg.matmul(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
+    return alg.matmul_x3(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
 
 
 def xyz_to_lin_prophoto(xyz: Vector) -> Vector:
     """Convert XYZ to linear-light prophoto-rgb."""
 
-    return alg.matmul(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
+    return alg.matmul_x3(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
 
 
 class ProPhotoRGBLinear(sRGBLinear):

--- a/coloraide/spaces/rec2020_linear.py
+++ b/coloraide/spaces/rec2020_linear.py
@@ -30,13 +30,13 @@ def lin_2020_to_xyz(rgb: Vector) -> Vector:
     http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
     """
 
-    return alg.matmul(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
+    return alg.matmul_x3(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
 
 
 def xyz_to_lin_2020(xyz: Vector) -> Vector:
     """Convert XYZ to linear-light rec-2020."""
 
-    return alg.matmul(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
+    return alg.matmul_x3(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
 
 
 class Rec2020Linear(sRGBLinear):

--- a/coloraide/spaces/rlab.py
+++ b/coloraide/spaces/rlab.py
@@ -71,7 +71,7 @@ class Environment:
     def calc_ram(self) -> Matrix:
         """Calculate RAM."""
 
-        lms = alg.matmul(M, self.ref_white, dims=alg.D2_D1)
+        lms = alg.matmul_x3(M, self.ref_white, dims=alg.D2_D1)
         a = []  # type: Vector
         s = sum(lms)
         for c in lms:
@@ -89,13 +89,13 @@ def rlab_to_xyz(rlab: Vector, env: Environment) -> Vector:
     yr = LR * 0.01
     xr = alg.spow((aR / 430) + yr, env.surround)
     zr = alg.spow(yr - (bR / 170), env.surround)
-    return alg.matmul(env.iram, [xr, alg.spow(yr, env.surround), zr], dims=alg.D2_D1)
+    return alg.matmul_x3(env.iram, [xr, alg.spow(yr, env.surround), zr], dims=alg.D2_D1)
 
 
 def xyz_to_rlab(xyz: Vector, env: Environment) -> Vector:
     """XYZ to RLAB."""
 
-    xyz_ref = alg.matmul(env.ram, xyz, dims=alg.D2_D1)
+    xyz_ref = alg.matmul_x3(env.ram, xyz, dims=alg.D2_D1)
     xr, yr, zr = (alg.nth_root(c, env.surround) for c in xyz_ref)
     LR = 100 * yr
     aR = 430 * (xr - yr)

--- a/coloraide/spaces/srgb_linear.py
+++ b/coloraide/spaces/srgb_linear.py
@@ -28,13 +28,13 @@ def lin_srgb_to_xyz(rgb: Vector) -> Vector:
     D65 (no chromatic adaptation)
     """
 
-    return alg.matmul(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
+    return alg.matmul_x3(RGB_TO_XYZ, rgb, dims=alg.D2_D1)
 
 
 def xyz_to_lin_srgb(xyz: Vector) -> Vector:
     """Convert XYZ to linear-light sRGB."""
 
-    return alg.matmul(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
+    return alg.matmul_x3(XYZ_TO_RGB, xyz, dims=alg.D2_D1)
 
 
 class sRGBLinear(RGBish, Space):

--- a/coloraide/spaces/xyb.py
+++ b/coloraide/spaces/xyb.py
@@ -49,9 +49,9 @@ XYB_TO_XYB_LMS = [
 def rgb_to_xyb(rgb: Vector) -> Vector:
     """Linear sRGB to XYB."""
 
-    return alg.matmul(
+    return alg.matmul_x3(
         XYB_LMS_TO_XYB,
-        [alg.nth_root(c + BIAS, 3) - BIAS_CBRT for c in alg.matmul(LRGB_TO_LMS, rgb, dims=alg.D2_D1)],
+        [alg.nth_root(c + BIAS, 3) - BIAS_CBRT for c in alg.matmul_x3(LRGB_TO_LMS, rgb, dims=alg.D2_D1)],
         dims=alg.D2_D1
     )
 
@@ -63,9 +63,9 @@ def xyb_to_rgb(xyb: Vector) -> Vector:
     if not any(xyb):
         return [0.0] * 3
 
-    return alg.matmul(
+    return alg.matmul_x3(
         LMS_TO_LRGB,
-        [(c + BIAS_CBRT) ** 3 - BIAS for c in alg.matmul(XYB_TO_XYB_LMS, xyb, dims=alg.D2_D1)],
+        [(c + BIAS_CBRT) ** 3 - BIAS for c in alg.matmul_x3(XYB_TO_XYB_LMS, xyb, dims=alg.D2_D1)],
         dims=alg.D2_D1
     )
 

--- a/coloraide/spaces/zcam_jmh.py
+++ b/coloraide/spaces/zcam_jmh.py
@@ -103,24 +103,24 @@ def adapt(
     yb = xyz_wb[1] / xyz_wo[1]
     yd = xyz_wd[1] / xyz_wo[1]
 
-    rgb_b = alg.dot(CAT02, xyz_b, dims=alg.D2_D1)
-    rgb_wb = alg.dot(CAT02, xyz_wb, dims=alg.D2_D1)
-    rgb_wd = alg.dot(CAT02, xyz_wd, dims=alg.D2_D1)
-    rgb_wo = alg.dot(CAT02, xyz_wo, dims=alg.D2_D1)
+    rgb_b = alg.matmul_x3(CAT02, xyz_b, dims=alg.D2_D1)
+    rgb_wb = alg.matmul_x3(CAT02, xyz_wb, dims=alg.D2_D1)
+    rgb_wd = alg.matmul_x3(CAT02, xyz_wd, dims=alg.D2_D1)
+    rgb_wo = alg.matmul_x3(CAT02, xyz_wo, dims=alg.D2_D1)
 
-    d_rgb_wb = alg.add(
-        alg.multiply(db * yb, alg.divide(rgb_wo, rgb_wb, dims=alg.D1), dims=alg.SC_D1),
+    d_rgb_wb = alg.add_x3(
+        alg.multiply_x3(db * yb, alg.divide_x3(rgb_wo, rgb_wb, dims=alg.D1), dims=alg.SC_D1),
         1 - db,
         dims=alg.D1_SC
     )
-    d_rgb_wd = alg.add(
-        alg.multiply(dd * yd, alg.divide(rgb_wo, rgb_wd, dims=alg.D1), dims=alg.SC_D1),
+    d_rgb_wd = alg.add_x3(
+        alg.multiply_x3(dd * yd, alg.divide_x3(rgb_wo, rgb_wd, dims=alg.D1), dims=alg.SC_D1),
         1 - dd,
         dims=alg.D1_SC
     )
-    d_rgb = alg.divide(d_rgb_wb, d_rgb_wd, dims=alg.D1)
-    rgb_d = alg.multiply(d_rgb, rgb_b, dims=alg.D1)
-    return alg.dot(CAT02_INV, rgb_d, dims=alg.D2_D1)
+    d_rgb = alg.divide_x3(d_rgb_wb, d_rgb_wd, dims=alg.D1)
+    rgb_d = alg.multiply_x3(d_rgb, rgb_b, dims=alg.D1)
+    return alg.matmul_x3(CAT02_INV, rgb_d, dims=alg.D2_D1)
 
 
 class Environment:

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 4.1.0
+## 4.2
+
+-   **NEW**: Add new matrix math functions that are specifically optimized for matrices and vectors of length 3 and
+    leverage it in all appropriate places for a performance boost.
+-   **NEW**: Combine logic of `algebra` optimized vectorize functions and deprecate unnecessary function.
+
+## 4.1
 
 -   **NEW**: The `powerless` parameter is deprecated in `average()` as it is required to be always on for proper polar
     space averaging.

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -1302,6 +1302,81 @@ class TestAlgebra(unittest.TestCase):
         with self.assertRaises(ValueError):
             alg.matmul(m1, m2)
 
+    def test_matmul_x3(self):
+        """
+        Test matrix multiplication.
+
+        Results should generally match 'dot' except scalars are not allowed and
+        logic for dimensions greater than 2 will be different. All other code
+        is shared.
+        """
+
+        self.assertEqual(alg.matmul_x3([1, 2, 3], [4, 5, 6]), 32)
+        self.assertEqual(alg.matmul_x3([4, 5, 6], [1, 2, 3]), 32)
+        self.assertEqual(
+            alg.matmul_x3(
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                [1, 2, 3]
+            ),
+            [14, 32, 50]
+        )
+        self.assertEqual(
+            alg.matmul_x3(
+                [1, 2, 3],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+            ),
+            [30, 36, 42]
+        )
+        self.assertEqual(
+            alg.matmul_x3(
+                [[4, 4, 4], [1, 0, 1], [2, 3, 4]],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+            ),
+            [[48, 60, 72], [8, 10, 12], [42, 51, 60]]
+        )
+
+        # Scalars are not allowed
+        with self.assertRaises(ValueError):
+            alg.matmul_x3([1, 2, 3], 3)
+
+        with self.assertRaises(ValueError):
+            alg.matmul_x3(3, [1, 2, 3])
+
+        m1 = [[[[1, 2, 3, 4],
+                [5, 6, 7, 8]],
+               [[10, 20, 30, 40],
+                [50, 60, 70, 80]],
+               [[15, 25, 35, 45],
+                [55, 65, 75, 85]]]]
+
+        m2 = [[[[11, 21],
+                [31, 41],
+                [51, 61],
+                [71, 81]],
+               [[21, 11],
+                [41, 12],
+                [51, 13],
+                [81, 14]],
+               [[2, 17],
+                [2, 2],
+                [9, 8],
+                [3, 4]]],
+              [[[5, 1],
+                [5, 41],
+                [5, 61],
+                [5, 81]],
+               [[21, 3],
+                [41, 3],
+                [51, 3],
+                [81, 3]],
+               [[4, 9],
+                [6, 7],
+                [1, 2],
+                [1, 5]]]]
+
+        with self.assertRaises(ValueError):
+            alg.matmul_x3(m1, m2)
+
     def test_dot(self):
         """Test dot."""
 
@@ -1388,7 +1463,7 @@ class TestAlgebra(unittest.TestCase):
 
               [[30, 50, 70, 90],
                [110, 130, 150, 170]]]]
-        ),
+        )
 
         self.assertEqual(
             alg.dot([40, 0.3, 12, 9], m2),
@@ -1402,6 +1477,45 @@ class TestAlgebra(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             alg.dot([1, 2, 3], [4, 5, 6, 7], dims=alg.D1)
+
+    def test_dot_x3(self):
+        """Test dot."""
+
+        self.assertEqual(alg.dot_x3(2, 2), 4)
+        self.assertEqual(alg.dot_x3([1, 2, 3], 2), [2, 4, 6])
+        self.assertEqual(alg.dot_x3(2, [1, 2, 3]), [2, 4, 6])
+        self.assertEqual(alg.dot_x3([1, 2, 3], [4, 5, 6]), 32)
+        self.assertEqual(alg.dot_x3([4, 5, 6], [1, 2, 3]), 32)
+        self.assertEqual(
+            alg.dot_x3(
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                [1, 2, 3]
+            ),
+            [14, 32, 50]
+        )
+        self.assertEqual(
+            alg.dot_x3(
+                [1, 2, 3],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+            ),
+            [30, 36, 42]
+        )
+        self.assertEqual(
+            alg.dot_x3(
+                [[4, 4, 4], [1, 0, 1], [2, 3, 4]],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+            ),
+            [[48, 60, 72], [8, 10, 12], [42, 51, 60]]
+        )
+
+        self.assertEqual(
+            alg.dot_x3(
+                [[4, 4, 4], [1, 0, 1], [2, 3, 4]],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                dims=alg.D2
+            ),
+            [[48, 60, 72], [8, 10, 12], [42, 51, 60]]
+        )
 
     def test_multi_dot(self):
         """Test multi-dot."""
@@ -1586,6 +1700,57 @@ class TestAlgebra(unittest.TestCase):
               [[45, 75, 105, 135], [165, 195, 225, 255]]]]
         )
 
+    def test_multiply_x3(self):
+        """Test multiply."""
+
+        self.assertEqual(alg.multiply_x3(2, 2), 4)
+        self.assertEqual(alg.multiply_x3([1, 2, 3], 2), [2, 4, 6])
+        self.assertEqual(alg.multiply_x3(2, [1, 2, 3]), [2, 4, 6])
+        self.assertEqual(alg.multiply_x3([1, 2, 3], [4, 5, 6]), [4, 10, 18])
+        self.assertEqual(alg.multiply_x3([4, 5, 6], [1, 2, 3]), [4, 10, 18])
+        self.assertEqual(
+            alg.multiply_x3(
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                [1, 2, 3]
+            ),
+            [[1, 4, 9], [4, 10, 18], [7, 16, 27]]
+        )
+        self.assertEqual(
+            alg.multiply_x3(
+                [1, 2, 3],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+            ),
+            [[1, 4, 9], [4, 10, 18], [7, 16, 27]]
+        )
+        self.assertEqual(
+            alg.multiply_x3(
+                [[4, 4, 4], [1, 0, 1], [2, 3, 4]],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+            ),
+            [[4, 8, 12], [4, 0, 6], [14, 24, 36]]
+        )
+        self.assertEqual(
+            alg.multiply_x3(
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                [[4, 4, 4], [1, 0, 1], [2, 3, 4]]
+            ),
+            [[4, 8, 12], [4, 0, 6], [14, 24, 36]]
+        )
+        self.assertEqual(
+            alg.multiply_x3(
+                [[4, 4, 4], [1, 0, 1], [2, 3, 4]],
+                2
+            ),
+            [[8, 8, 8], [2, 0, 2], [4, 6, 8]]
+        )
+        self.assertEqual(
+            alg.multiply_x3(
+                2,
+                [[4, 4, 4], [1, 0, 1], [2, 3, 4]]
+            ),
+            [[8, 8, 8], [2, 0, 2], [4, 6, 8]]
+        )
+
     def test_divide(self):
         """Test divide."""
 
@@ -1668,6 +1833,66 @@ class TestAlgebra(unittest.TestCase):
         )
         self.assertEqual(alg.divide(8, 4), 2)
 
+    def test_divide_x3(self):
+        """Test divide."""
+
+        self.assertEqual(alg.divide_x3(4, 2), 2)
+        self.assertEqual(alg.divide_x3([2, 4, 6], 2), [1, 2, 3])
+        self.assertEqual(alg.divide_x3(2, [2, 4, 6]), [1.0, 0.5, 0.3333333333333333])
+        self.assertEqual(alg.divide_x3([4, 10, 18], [4, 5, 6]), [1, 2, 3])
+        self.assertEqual(alg.divide_x3([4, 10, 18], [1, 2, 3]), [4, 5, 6])
+        self.assertEqual(
+            alg.divide_x3(
+                [[1, 4, 9], [4, 10, 18], [7, 16, 27]],
+                [1, 2, 3]
+            ),
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        self.assertEqual(
+            alg.divide_x3(
+                [1, 2, 3],
+                [[1, 4, 9], [4, 10, 18], [7, 16, 27]]
+            ),
+            [
+                [1.0, 0.5, 0.3333333333333333],
+                [0.25, 0.2, 0.16666666666666666],
+                [0.14285714285714285, 0.125, 0.1111111111111111]
+            ]
+        )
+        self.assertEqual(
+            alg.divide_x3(
+                [[1, 4, 9], [4, 10, 18], [7, 16, 27]],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+            ),
+            [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]
+        )
+        self.assertEqual(
+            alg.divide_x3(
+                [[4, 8, 12], [4, 0, 6], [14, 24, 36]],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+            ),
+            [[4, 4, 4], [1, 0, 1], [2, 3, 4]]
+        )
+        self.assertEqual(
+            alg.divide_x3(
+                [[4, 8, 12], [4, 0, 6], [14, 24, 36]],
+                2
+            ),
+            [[2.0, 4.0, 6.0], [2.0, 0.0, 3.0], [7.0, 12.0, 18.0]]
+        )
+        self.assertEqual(
+            alg.divide_x3(
+                2,
+                [[4, 8, 12], [4, 1, 6], [14, 24, 36]]
+            ),
+            [
+                [0.5, 0.25, 0.16666666666666666],
+                [0.5, 2.0, 0.3333333333333333],
+                [0.14285714285714285, 0.08333333333333333, 0.05555555555555555]
+            ]
+        )
+        self.assertEqual(alg.divide_x3(8, 4), 2)
+
     def test_add(self):
         """Test addition."""
 
@@ -1688,6 +1913,36 @@ class TestAlgebra(unittest.TestCase):
 
         self.assertEqual(
             alg.subtract(
+                alg.reshape(alg.arange(9.0), (3, 3)),
+                alg.arange(3.0)
+            ),
+            [
+                [0.0, 0.0, 0.0],
+                [3.0, 3.0, 3.0],
+                [6.0, 6.0, 6.0]
+            ]
+        )
+
+    def test_add_x3(self):
+        """Test addition."""
+
+        self.assertEqual(
+            alg.add_x3(
+                alg.reshape(alg.arange(9.0), (3, 3)),
+                alg.arange(3.0)
+            ),
+            [
+                [0.0, 2.0, 4.0],
+                [3.0, 5.0, 7.0],
+                [6.0, 8.0, 10.0]
+            ]
+        )
+
+    def test_subtraction3(self):
+        """Test subtraction."""
+
+        self.assertEqual(
+            alg.subtract_x3(
                 alg.reshape(alg.arange(9.0), (3, 3)),
                 alg.arange(3.0)
             ),
@@ -1770,7 +2025,7 @@ class TestAlgebra(unittest.TestCase):
     def test_vectorize1(self):
         """Test `vectorize1`."""
 
-        cbrt = alg.vectorize1(lambda x: alg.nth_root(x, 3))
+        cbrt = alg.vectorize2(lambda x: alg.nth_root(x, 3), params=1)
 
         self.assertEqual(
             cbrt([8, 27]),
@@ -1779,6 +2034,39 @@ class TestAlgebra(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             cbrt([8, 27], 4)
+
+        cbrt_x3 = alg.vectorize2(lambda x: alg.nth_root(x, 3), params=1, only_x3=True)
+
+        self.assertEqual(
+            cbrt_x3([8, 27, 27]),
+            [2, 3, 3]
+        )
+
+        self.assertEqual(
+            cbrt_x3([8, 27, 27], dims=alg.D1),
+            [2, 3, 3]
+        )
+
+        self.assertEqual(
+            cbrt_x3(27),
+            3
+        )
+
+        self.assertEqual(
+            cbrt_x3(
+                [[8, 27, 27], [8, 27, 27], [8, 27, 27]]
+            ),
+            [[2, 3, 3], [2, 3, 3], [2, 3, 3]]
+        )
+
+        with self.assertRaises(ValueError):
+            cbrt_x3(
+                [
+                    [[8, 27, 27], [8, 27, 27], [8, 27, 27]],
+                    [[8, 27, 27], [8, 27, 27], [8, 27, 27]],
+                    [[8, 27, 27], [8, 27, 27], [8, 27, 27]]
+                ]
+            )
 
     def test_vectorize2(self):
         """Test `vectorize2`."""
@@ -1798,6 +2086,20 @@ class TestAlgebra(unittest.TestCase):
         with self.assertRaises(TypeError):
             log([10, 100])
 
+        with self.assertRaises(ValueError):
+            alg.vectorize2(math.log, params=3)
+
+        root = alg.vectorize2(alg.nth_root, only_x3=True)
+        with self.assertRaises(ValueError):
+            root(
+                [
+                    [[1, 2, 3], [1, 2, 3], [1, 2, 3]],
+                    [[1, 2, 3], [1, 2, 3], [1, 2, 3]],
+                    [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
+                ],
+                3
+            )
+
     def test_apply_two_inputs(self):
         """Test vectorize2 with two inputs."""
 
@@ -1810,13 +2112,13 @@ class TestAlgebra(unittest.TestCase):
     def test_apply_one_input(self):
         """Test apply with one input."""
 
-        sqrt = alg.vectorize1(math.sqrt)
+        sqrt = alg.vectorize2(math.sqrt, params=1)
         self.assertEqual(
             sqrt([[1, 4, 9], [16, 25, 36]]),
             [[1, 2, 3], [4, 5, 6]]
         )
 
-        isnan = alg.vectorize1(math.isnan)
+        isnan = alg.vectorize2(math.isnan, params=1)
         self.assertTrue(isnan(math.nan))
         self.assertEqual(isnan([2, math.nan, 1]), [False, True, False])
         self.assertEqual(isnan([[2, math.nan], [math.nan, 1]]), [[False, True], [True, False]])


### PR DESCRIPTION
Majority of array operations in ColorAide are performed on 3x3 matrices and length 3 vectors. Knowing this, we can provide math functions that are less generalized and avoid loops creating more performant operations.

Combine the functionality of vectorize1 and vectorize2 such that we now just have vectorize2 with the parameter `params` which can be set to 1 or 2 (2 being the default) and will and can vectorize functions that accept 1 or 2 array parameters. vectorize1 is now deprecated. These functions, as always, are still limited to dimensions of 2 or less.

Additionally, provide a new `only_x3` parameter to vectorize2 that will allow us to use an even more optimized logic when vectorizing a function with the limitation that the matrix or vector must have dimension lengths of 3.

Lastly, create new optimized functions: matmul_x3, dot_x3, multiply_x3, divide_x3, add_x3, and subtract_x3 which require arrays of dimensions less than 2 and dimension lengths of 3 and will perform much faster.

Replace all applicable calls with these new x3 variants of basic math functions.

Resolves #447 