### PR TITLE
Fix shape typing and other related typing issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 5
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
 
     runs-on: ${{ matrix.platform }}
 
@@ -48,7 +48,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.13']
 
     env:
       TOXENV: lint
@@ -72,7 +72,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.13']
 
     env:
       TOXENV: documents

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Package
         run: |
           pip install --upgrade pip build

--- a/coloraide/algebra.py
+++ b/coloraide/algebra.py
@@ -3624,13 +3624,13 @@ def solve(a: MatrixLike | TensorLike, b: ArrayLike) -> Array:
             sol_v = not sol_m and not p1 % p2
         elif s2[-2] == size:  # type: ignore[misc]
             # One matrix of equations with multiple series of K dependent variable sets (matrix)
-            p1 = prod(s[:-1])  # type: ignore[misc, unused-ignore]
-            p2 = prod(s2[:-1])  # type: ignore[misc, unused-ignore]
+            p1 = prod(s[:-1])  # type: ignore[misc]
+            p2 = prod(s2[:-1])  # type: ignore[misc]
             sol_m = not p2 % p1
     elif s2[-1] == size:
         # Multiple equations sets with a single series of dependent variables per equation set (vectors)
-        p1 = prod(s[:-2])  # type: ignore[misc, unused-ignore]
-        p2 = prod(s2[:-1])  # type: ignore[misc, unused-ignore]
+        p1 = prod(s[:-2])  # type: ignore[misc]
+        p2 = prod(s2[:-1])  # type: ignore[misc]
         sol_v = p1 == p2
 
     # Matrix and matrices
@@ -3639,7 +3639,7 @@ def solve(a: MatrixLike | TensorLike, b: ArrayLike) -> Array:
         ma = [rows_equ[r:r + size] for r in range(0, len(rows_equ), size)]
         rows_sol = list(_extract_rows(b, s2))
         mb = [rows_sol[r:r + size] for r in range(0, len(rows_sol), size)]
-        ai_shape = s[-2:]  # type: ignore[misc, unused-ignore]
+        ai_shape = s[-2:]  # type: ignore[misc]
 
         p, l, u = lu(ma[0], p_indices=True, _shape=ai_shape)
 
@@ -3657,7 +3657,7 @@ def solve(a: MatrixLike | TensorLike, b: ArrayLike) -> Array:
         rows_equ = list(_extract_rows(a, s))
         ma = [rows_equ[r:r + size] for r in range(0, len(rows_equ), size)]
         mv = list(_extract_rows(b, s2))
-        ai_shape = s[-2:]  # type: ignore[misc, unused-ignore]
+        ai_shape = s[-2:]  # type: ignore[misc]
 
         for ai, vi in zip(ma, mv):
             p, l, u = lu(ai, p_indices=True, _shape=ai_shape)
@@ -3701,7 +3701,7 @@ def det(array: MatrixLike | TensorLike) -> float | Vector:
         dt = sign * prod(l[i][i] * u[i][i] for i in range(size))
         return 0.0 if not dt else dt
     else:
-        last = s[-2:]  # type: ignore[misc, unused-ignore]
+        last = s[-2:]  # type: ignore[misc]
         rows = list(_extract_rows(array, s))
         step = last[-2]
         return [det(rows[r:r + step]) for r in range(0, len(rows), step)]
@@ -3723,7 +3723,7 @@ def inv(matrix: MatrixLike | TensorLike) -> Matrix | Tensor:
     # Ensure we have a square matrix
     s = shape(matrix)
     dims = len(s)
-    last = s[-2:]  # type: ignore[misc, unused-ignore]
+    last = s[-2:]  # type: ignore[misc]
     if dims < 2 or min(last) != max(last):
         raise ValueError('Matrix must be a N x N matrix')
 
@@ -3820,7 +3820,7 @@ def vstack(arrays: Sequence[ArrayLike | float]) -> Matrix | Tensor:
                 raise ValueError('All the input array dimensions except for the concatenation axis must match exactly')
 
         # Stack the arrays
-        m.extend(reshape(a, (prod(s[:1 - dims]),) + s[1 - dims:-1] + s[-1:]))  # type: ignore[arg-type, misc, unused-ignore]
+        m.extend(reshape(a, (prod(s[:1 - dims]),) + s[1 - dims:-1] + s[-1:]))  # type: ignore[arg-type, misc]
 
         # Update the last array tracker
         if not last or len(last) > len(s):
@@ -4044,7 +4044,7 @@ def inner(a: float | ArrayLike, b: float | ArrayLike) -> float | Array:
 
     # Perform the actual inner product
     m = [[sum([x * y for x, y in it.zip_longest(r1, r2)]) for r2 in second] for r1 in first]
-    new_shape = shape_a[:-1] + shape_b[:-1]  # type: ignore[misc, unused-ignore]
+    new_shape = shape_a[:-1] + shape_b[:-1]  # type: ignore[misc]
 
     # Shape the data.
     return reshape(m, new_shape)  # type: ignore[arg-type]

--- a/coloraide/algebra.py
+++ b/coloraide/algebra.py
@@ -1956,16 +1956,15 @@ def broadcast_to(a: ArrayLike | float, s: int | Shape) -> float | Array:
     """Broadcast array to a shape."""
 
     _s = (s,) if not isinstance(s, Sequence) else tuple(s)
-    _a = [a] if not isinstance(a, Sequence) else a
 
-    s_orig = shape(_a)
+    s_orig = shape(a)
     ndim_orig = len(s_orig)
     ndim_target = len(_s)
     if ndim_orig > ndim_target:
         raise ValueError(f"Cannot broadcast {s_orig} to {_s}")
 
     if not ndim_target:
-        return _a  # type: ignore[return-value]
+        return a  # type: ignore[return-value]
 
     s1 = list(s_orig)
     if ndim_orig < ndim_target:

--- a/coloraide/algebra.py
+++ b/coloraide/algebra.py
@@ -3624,13 +3624,13 @@ def solve(a: MatrixLike | TensorLike, b: ArrayLike) -> Array:
             sol_v = not sol_m and not p1 % p2
         elif s2[-2] == size:  # type: ignore[misc]
             # One matrix of equations with multiple series of K dependent variable sets (matrix)
-            p1 = prod(s[:-1])  # type: ignore[misc]
-            p2 = prod(s2[:-1])  # type: ignore[misc]
+            p1 = prod(s[:-1])  # type: ignore[misc, unused-ignore]
+            p2 = prod(s2[:-1])  # type: ignore[misc, unused-ignore]
             sol_m = not p2 % p1
     elif s2[-1] == size:
         # Multiple equations sets with a single series of dependent variables per equation set (vectors)
-        p1 = prod(s[:-2])  # type: ignore[misc]
-        p2 = prod(s2[:-1])  # type: ignore[misc]
+        p1 = prod(s[:-2])  # type: ignore[misc, unused-ignore]
+        p2 = prod(s2[:-1])  # type: ignore[misc, unused-ignore]
         sol_v = p1 == p2
 
     # Matrix and matrices
@@ -3639,7 +3639,7 @@ def solve(a: MatrixLike | TensorLike, b: ArrayLike) -> Array:
         ma = [rows_equ[r:r + size] for r in range(0, len(rows_equ), size)]
         rows_sol = list(_extract_rows(b, s2))
         mb = [rows_sol[r:r + size] for r in range(0, len(rows_sol), size)]
-        ai_shape = s[-2:]  # type: ignore[misc]
+        ai_shape = s[-2:]  # type: ignore[misc, unused-ignore]
 
         p, l, u = lu(ma[0], p_indices=True, _shape=ai_shape)
 
@@ -3657,7 +3657,7 @@ def solve(a: MatrixLike | TensorLike, b: ArrayLike) -> Array:
         rows_equ = list(_extract_rows(a, s))
         ma = [rows_equ[r:r + size] for r in range(0, len(rows_equ), size)]
         mv = list(_extract_rows(b, s2))
-        ai_shape = s[-2:]  # type: ignore[misc]
+        ai_shape = s[-2:]  # type: ignore[misc, unused-ignore]
 
         for ai, vi in zip(ma, mv):
             p, l, u = lu(ai, p_indices=True, _shape=ai_shape)
@@ -3701,7 +3701,7 @@ def det(array: MatrixLike | TensorLike) -> float | Vector:
         dt = sign * prod(l[i][i] * u[i][i] for i in range(size))
         return 0.0 if not dt else dt
     else:
-        last = s[-2:]  # type: ignore[misc]
+        last = s[-2:]  # type: ignore[misc, unused-ignore]
         rows = list(_extract_rows(array, s))
         step = last[-2]
         return [det(rows[r:r + step]) for r in range(0, len(rows), step)]
@@ -3723,7 +3723,7 @@ def inv(matrix: MatrixLike | TensorLike) -> Matrix | Tensor:
     # Ensure we have a square matrix
     s = shape(matrix)
     dims = len(s)
-    last = s[-2:]  # type: ignore[misc]
+    last = s[-2:]  # type: ignore[misc, unused-ignore]
     if dims < 2 or min(last) != max(last):
         raise ValueError('Matrix must be a N x N matrix')
 
@@ -3820,7 +3820,7 @@ def vstack(arrays: Sequence[ArrayLike | float]) -> Matrix | Tensor:
                 raise ValueError('All the input array dimensions except for the concatenation axis must match exactly')
 
         # Stack the arrays
-        m.extend(reshape(a, (prod(s[:1 - dims]),) + s[1 - dims:-1] + s[-1:]))  # type: ignore[arg-type, misc]
+        m.extend(reshape(a, (prod(s[:1 - dims]),) + s[1 - dims:-1] + s[-1:]))  # type: ignore[arg-type, misc, unused-ignore]
 
         # Update the last array tracker
         if not last or len(last) > len(s):
@@ -4044,7 +4044,7 @@ def inner(a: float | ArrayLike, b: float | ArrayLike) -> float | Array:
 
     # Perform the actual inner product
     m = [[sum([x * y for x, y in it.zip_longest(r1, r2)]) for r2 in second] for r1 in first]
-    new_shape = shape_a[:-1] + shape_b[:-1]  # type: ignore[misc]
+    new_shape = shape_a[:-1] + shape_b[:-1]  # type: ignore[misc, unused-ignore]
 
     # Shape the data.
     return reshape(m, new_shape)  # type: ignore[arg-type]

--- a/coloraide/types.py
+++ b/coloraide/types.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 import sys
 from typing import Union, Any, Mapping, Sequence, TypeVar, TYPE_CHECKING
-
+if (3, 11) <= sys.version_info:
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
 if TYPE_CHECKING:  # pragma: no cover
     from .color import Color
 
@@ -36,13 +39,7 @@ ArrayInt = MatrixInt | VectorInt | TensorInt
 FloatShape = tuple[()]
 VectorShape = tuple[int]
 MatrixShape = tuple[int, int]
-
-if (3, 11) <= sys.version_info:
-    TensorShape = tuple[int, int, int, *tuple[int, ...]]
-else:
-    # For versions below 3.10, just treat tensors as one deper than a Matrix.
-    # We don't directly use tensors in ColorAide even though they are supported.
-    TensorShape = tuple[int, int, int]
+TensorShape = tuple[int, int, int, Unpack[tuple[int, ...]]]
 
 ArrayShape = tuple[int, ...]
 Shape = FloatShape | ArrayShape

--- a/coloraide/types.py
+++ b/coloraide/types.py
@@ -2,7 +2,7 @@
 """Typing."""
 from __future__ import annotations
 import sys
-from typing import Union, Any, Mapping, Sequence, TypeVar, TYPE_CHECKING
+from typing import Union, Any, Mapping, Sequence, List, Tuple, TypeVar, TYPE_CHECKING
 if (3, 11) <= sys.version_info:
     from typing import Unpack
 else:
@@ -13,38 +13,38 @@ if TYPE_CHECKING:  # pragma: no cover
 ColorInput = Union['Color', str, Mapping[str, Any]]
 
 # Vectors, Matrices, and Arrays are assumed to be mutable lists
-Vector = list[float]
-Matrix = list[Vector]
-Tensor = list[list[list[float | Any]]]
-Array = Matrix | Vector | Tensor
+Vector = List[float]
+Matrix = List[Vector]
+Tensor = List[List[List[Union[float, Any]]]]
+Array = Union[Matrix, Vector, Tensor]
 
 # Anything that resembles a sequence will be considered "like" one of our types above
 VectorLike = Sequence[float]
 MatrixLike = Sequence[VectorLike]
-TensorLike = Sequence[Sequence[Sequence[float | Any]]]
-ArrayLike = VectorLike | MatrixLike | TensorLike
+TensorLike = Sequence[Sequence[Sequence[Union[float, Any]]]]
+ArrayLike = Union[VectorLike, MatrixLike, TensorLike]
 
 # Vectors, Matrices, and Arrays of various, specific types
-VectorBool = list[bool]
-MatrixBool = list[VectorBool]
-TensorBool = list[list[list[bool | Any]]]
-ArrayBool = MatrixBool | VectorBool | TensorBool
+VectorBool = List[bool]
+MatrixBool = List[VectorBool]
+TensorBool = List[List[List[Union[bool, Any]]]]
+ArrayBool = Union[MatrixBool, VectorBool, TensorBool]
 
-VectorInt = list[int]
-MatrixInt = list[VectorInt]
-TensorInt = list[list[list[int | Any]]]
-ArrayInt = MatrixInt | VectorInt | TensorInt
+VectorInt = List[int]
+MatrixInt = List[VectorInt]
+TensorInt = List[List[List[Union[int, Any]]]]
+ArrayInt = Union[MatrixInt, VectorInt, TensorInt]
 
 # General algebra types
-FloatShape = tuple[()]
-VectorShape = tuple[int]
-MatrixShape = tuple[int, int]
-TensorShape = tuple[int, int, int, Unpack[tuple[int, ...]]]
+FloatShape = Tuple[()]
+VectorShape = Tuple[int]
+MatrixShape = Tuple[int, int]
+TensorShape = Tuple[int, int, int, Unpack[Tuple[int, ...]]]
 
-ArrayShape = tuple[int, ...]
-Shape = FloatShape | ArrayShape
+ArrayShape = Tuple[int, ...]
+Shape = Union[FloatShape, ArrayShape]
 ShapeLike = Sequence[int]
-DimHints = tuple[int, int]
+DimHints = Tuple[int, int]
 
 # For times when we must explicitly say we support `int` and `float`
 SupportsFloatOrInt = TypeVar('SupportsFloatOrInt', float, int)

--- a/coloraide/types.py
+++ b/coloraide/types.py
@@ -2,7 +2,7 @@
 """Typing."""
 from __future__ import annotations
 import sys
-from typing import Union, Any, Mapping, Sequence, TypeVar, TypeAlias, TYPE_CHECKING
+from typing import Union, Any, Mapping, Sequence, TypeVar, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from .color import Color
@@ -38,7 +38,7 @@ VectorShape = tuple[int]
 MatrixShape = tuple[int, int]
 
 if (3, 11) <= sys.version_info:
-    TensorShape: TypeAlias = "tuple[int, int, int, *tuple[int, ...]]"
+    TensorShape = tuple[int, int, int, *tuple[int, ...]]
 else:
     # For versions below 3.10, just treat tensors as one deper than a Matrix.
     # We don't directly use tensors in ColorAide even though they are supported.

--- a/coloraide/types.py
+++ b/coloraide/types.py
@@ -1,7 +1,7 @@
 # noqa: A005
 """Typing."""
 from __future__ import annotations
-from typing import Union, Any, Mapping, Sequence, List, Tuple, TypeVar, TYPE_CHECKING
+from typing import Union, Any, Mapping, Sequence, TypeVar, TypeAlias, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from .color import Color
@@ -9,37 +9,38 @@ if TYPE_CHECKING:  # pragma: no cover
 ColorInput = Union['Color', str, Mapping[str, Any]]
 
 # Vectors, Matrices, and Arrays are assumed to be mutable lists
-Vector = List[float]
-Matrix = List[Vector]
-Tensor = List[List[List[Union[float, Any]]]]
-Array = Union[Matrix, Vector, Tensor]
+Vector = list[float]
+Matrix = list[Vector]
+Tensor = list[list[list[float | Any]]]
+Array = Matrix | Vector | Tensor
 
 # Anything that resembles a sequence will be considered "like" one of our types above
 VectorLike = Sequence[float]
 MatrixLike = Sequence[VectorLike]
-TensorLike = Sequence[Sequence[Sequence[Union[float, Any]]]]
-ArrayLike = Union[VectorLike, MatrixLike, TensorLike]
+TensorLike = Sequence[Sequence[Sequence[float | Any]]]
+ArrayLike = VectorLike | MatrixLike | TensorLike
 
 # Vectors, Matrices, and Arrays of various, specific types
-VectorBool = List[bool]
-MatrixBool = List[VectorBool]
-TensorBool = List[List[List[Union[bool, Any]]]]
-ArrayBool = Union[MatrixBool, VectorBool, TensorBool]
+VectorBool = list[bool]
+MatrixBool = list[VectorBool]
+TensorBool = list[list[list[bool | Any]]]
+ArrayBool = MatrixBool | VectorBool | TensorBool
 
-VectorInt = List[int]
-MatrixInt = List[VectorInt]
-TensorInt = List[List[List[Union[int, Any]]]]
-ArrayInt = Union[MatrixInt, VectorInt, TensorInt]
+VectorInt = list[int]
+MatrixInt = list[VectorInt]
+TensorInt = list[list[list[int | Any]]]
+ArrayInt = MatrixInt | VectorInt | TensorInt
 
 # General algebra types
-FloatShape = Tuple[()]
-VectorShape = Tuple[int]
-MatrixShape = Tuple[int, int]
-TensorShape = Tuple[int, int, int, *Tuple[int, ...]]
-ArrayShape = Tuple[int, ...]
+FloatShape = tuple[()]
+VectorShape = tuple[int]
+MatrixShape = tuple[int, int]
+TensorShape: TypeAlias = "tuple[int, int, int, *tuple[int, ...]]"
+
+ArrayShape = tuple[int, ...]
 Shape = FloatShape | ArrayShape
 ShapeLike = Sequence[int]
-DimHints = Tuple[int, int]
+DimHints = tuple[int, int]
 
 # For times when we must explicitly say we support `int` and `float`
 SupportsFloatOrInt = TypeVar('SupportsFloatOrInt', float, int)

--- a/coloraide/types.py
+++ b/coloraide/types.py
@@ -1,6 +1,7 @@
 # noqa: A005
 """Typing."""
 from __future__ import annotations
+import sys
 from typing import Union, Any, Mapping, Sequence, TypeVar, TypeAlias, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -35,7 +36,13 @@ ArrayInt = MatrixInt | VectorInt | TensorInt
 FloatShape = tuple[()]
 VectorShape = tuple[int]
 MatrixShape = tuple[int, int]
-TensorShape: TypeAlias = "tuple[int, int, int, *tuple[int, ...]]"
+
+if (3, 11) <= sys.version_info:
+    TensorShape: TypeAlias = "tuple[int, int, int, *tuple[int, ...]]"
+else:
+    # For versions below 3.10, just treat tensors as one deper than a Matrix.
+    # We don't directly use tensors in ColorAide even though they are supported.
+    TensorShape = tuple[int, int, int]
 
 ArrayShape = tuple[int, ...]
 Shape = FloatShape | ArrayShape

--- a/coloraide/types.py
+++ b/coloraide/types.py
@@ -32,7 +32,12 @@ TensorInt = List[List[List[Union[int, Any]]]]
 ArrayInt = Union[MatrixInt, VectorInt, TensorInt]
 
 # General algebra types
-Shape = Tuple[int, ...]
+FloatShape = Tuple[()]
+VectorShape = Tuple[int]
+MatrixShape = Tuple[int, int]
+TensorShape = Tuple[int, int, int, *Tuple[int, ...]]
+ArrayShape = Tuple[int, ...]
+Shape = FloatShape | ArrayShape
 ShapeLike = Sequence[int]
 DimHints = Tuple[int, int]
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3
+
+-   **NEW**: Drop Python 3.8 support as it is "end of life".
+
 ## 4.2.2
 
 -   **FIX**: More precise inverse of RYB Biased.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,6 +3,7 @@
 ## 4.3
 
 -   **NEW**: Drop Python 3.8 support as it is "end of life".
+-   **FIX**: Typing fixes.
 
 ## 4.2.2
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -29,7 +29,6 @@ class CustomMetadataHook(MetadataHookInterface):
             "License :: OSI Approved :: MIT License",
             "Operating System :: OS Independent",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ legacy_tox_ini = """
     [tox]
     isolated_build = true
     envlist=
-        py38,py39,py310,py311,py312,py313,
+        py39,py310,py311,py312,py313,
         lint
 
     [testenv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ name = "coloraide"
 description = "A color library for Python."
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
+dependencies = [
+    "typing-extensions;python_version<'3.11'"
+]
 authors = [
     { name = "Isaac Muse", email = "Isaac.Muse@gmail.com" },
 ]
@@ -30,7 +33,6 @@ keywords = [
 ]
 dynamic = [
     "classifiers",
-    "dependencies",
     "version",
 ]
 

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -677,6 +677,14 @@ class TestAlgebra(unittest.TestCase):
             [3, 3, 3]
         )
 
+        self.assertEqual(
+            alg.broadcast_to(3, ()),
+            3
+        )
+
+        with self.assertRaises(ValueError):
+            alg.broadcast_to([1, 2, 3], ())
+
         # Can't broadcast to a smaller size
         with self.assertRaises(ValueError):
             alg.broadcast_to([[3, 3, 3], [3, 3, 3]], (3,))

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -2209,7 +2209,7 @@ class TestAlgebra(unittest.TestCase):
     def test_lerp2d(self):
         """Test 2D interpolation."""
 
-        m = [[0.1, 0.0], [1.0, 0.0], [0.0, .95], [1, 1]]
+        m = [[0.1, 0.0], [1.0, 0.0], [0.0, .95], [1.0, 1.0]]
         v = alg.lerp2d(alg.transpose(m), [0.5, 0.5])
         [self.assertAlmostEqual(a, b) for a, b in zip(v, [0.525, 0.4875])]
         v = alg.lerp2d(alg.transpose(m), [0.0, 0.0])
@@ -2224,7 +2224,7 @@ class TestAlgebra(unittest.TestCase):
     def test_ilerp2d(self):
         """Test inverse 2D interpolation."""
 
-        m = [[0.1, 0.0], [1.0, 0.0], [0.0, .95], [1, 1]]
+        m = [[0.1, 0.0], [1.0, 0.0], [0.0, .95], [1.0, 1.0]]
         v = alg.ilerp2d(alg.transpose(m), [0.525, 0.4875])
         [self.assertAlmostEqual(a, b) for a, b in zip(v, [0.5, 0.5])]
         v = alg.ilerp2d(alg.transpose(m), [0.1, 0.0])


### PR DESCRIPTION
- Narrow the shape type to tuples which we can actually have a more fine grained approach with.
- In a few cases we could accept a float shape of an empty tuple, but that was not communicated by certain functions.

Typing is messy and not perfect in algebra lib, but this should help a bit. Ignore cases where things are too dynamic for mypy to figure things out.