### PR TITLE
Add new get_space method to Interpolate plugins

### DIFF
--- a/coloraide/interpolate/__init__.py
+++ b/coloraide/interpolate/__init__.py
@@ -488,6 +488,17 @@ class Interpolate(Plugin, metaclass=ABCMeta):
     ) -> Interpolator:
         """Get the interpolator object."""
 
+    def get_space(self, space: str | None, color_cls: type[Color]) -> str:
+        """
+        Get and validate the color space for interpolation.
+
+        If no space is defined, return an appropriate default color space.
+        """
+
+        if space is None:
+            space = color_cls.INTERPOLATE
+        return space
+
 
 def calc_stops(stops: dict[int, float], count: int) -> dict[int, float]:
     """Calculate stops."""
@@ -678,8 +689,7 @@ def interpolator(
     # Construct piecewise interpolation object
     stops = {}  # type: Any
 
-    if space is None:
-        space = color_cls.INTERPOLATE
+    space = plugin.get_space(space, color_cls)
 
     if not colors:
         raise ValueError('At least one color must be specified.')

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,6 +2,8 @@
 
 ## 4.3
 
+-   **NEW**: Interpolate plugins now define a `get_space` hook allowing them to validate and return an appropriate
+    default space if the normal default cannot be supported.
 -   **NEW**: Drop Python 3.8 support as it is "end of life".
 -   **FIX**: Typing fixes.
 

--- a/docs/src/markdown/plugins/interpolate.md
+++ b/docs/src/markdown/plugins/interpolate.md
@@ -33,11 +33,23 @@ class Interpolate(Plugin, metaclass=ABCMeta):
         **kwargs: Any
     ) -> Interpolator:
         """Get the interpolator object."""
+
+    def get_space(self, space: str | None, color_cls: type[Color]) -> str:
+        """
+        Get and validate the color space for interpolation.
+
+        If no space is defined, return an appropriate default color space.
+        """
 ```
 
 Once registered, the plugin can then be used via `interpolate`, `steps`, or `mix` by passing its `NAME` via the `method`
 parameter along with any additional key word arguments to override default behavior. An `Interpolator` object will be
 returned which allows for interpolating between the given list of `colors`.
+
+The `Interpolate` class also defines a `get_space` method that will be passed a the user defined space (if one is
+specified) and can validate whether the space is supported, raising an error if not, or return the space. If a space
+is not specified, an appropriate default can be returned, usually `Color.INTERPOLATE` but can differ if the interpolator
+can only support very specific spaces.
 
 ```py
 color.interpolate(colors, method=NAME)


### PR DESCRIPTION
Interpolate plugins can control valid spaces to interpolate within. An appropriate default can be provided that differs from the usual default if explicitly necessary. An error can be raised if a user defines an unsupported space for a given interpolator.