### PR TITLE
Handle achromatic threshold better

### DIFF
--- a/coloraide/average.py
+++ b/coloraide/average.py
@@ -1,15 +1,13 @@
 """Average colors together."""
 from __future__ import annotations
 import math
+from . import util
 from .spaces import HWBish
 from .types import ColorInput
 from typing import Iterable, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from .color import Color
-
-
-ACHROMATIC_THRESHOLD = 1e-4
 
 
 def average(
@@ -88,7 +86,7 @@ def average(
             else:
                 sin /= total
                 cos /= total
-            if abs(sin) < ACHROMATIC_THRESHOLD and abs(cos) < ACHROMATIC_THRESHOLD:
+            if abs(sin) < util.ACHROMATIC_THRESHOLD_SM and abs(cos) < util.ACHROMATIC_THRESHOLD_SM:
                 sums[i] = math.nan
             else:
                 avg_theta = math.degrees(math.atan2(sin, cos))

--- a/coloraide/spaces/cam16_jmh.py
+++ b/coloraide/spaces/cam16_jmh.py
@@ -12,10 +12,9 @@ import math
 import bisect
 from .. import util
 from .. import algebra as alg
-from ..spaces import Space, LChish
+from .lch import LCh
 from ..cat import WHITES, CAT16
 from ..channels import Channel, FLG_ANGLE
-from .lch import ACHROMATIC_THRESHOLD
 from ..types import Vector, VectorLike
 
 # CAT16
@@ -352,7 +351,7 @@ def cam_jmh_to_xyz(jmh: Vector, env: Environment) -> Vector:
     return cam_to_xyz(J=J, M=M, h=h, env=env)
 
 
-class CAM16JMh(LChish, Space):
+class CAM16JMh(LCh):
     """CAM16 class (JMh)."""
 
     BASE = "xyz-d65"
@@ -396,7 +395,7 @@ class CAM16JMh(LChish, Space):
         """Check if color is achromatic."""
 
         # Account for both positive and negative chroma
-        return coords[0] == 0 or abs(coords[1]) < ACHROMATIC_THRESHOLD
+        return coords[0] == 0 or abs(coords[1]) < self.achromatic_threshold
 
     def to_base(self, coords: Vector) -> Vector:
         """From CAM16 JMh to XYZ."""

--- a/coloraide/spaces/cam16_ucs.py
+++ b/coloraide/spaces/cam16_ucs.py
@@ -8,8 +8,7 @@ https://doi.org/10.1002/col.22131
 from __future__ import annotations
 import math
 from .cam16_jmh import CAM16JMh, xyz_to_cam, cam_to_xyz, Environment
-from ..spaces import Space, Labish
-from .lch import ACHROMATIC_THRESHOLD
+from .lab import Lab
 from ..cat import WHITES
 from .. import util
 from ..channels import Channel, FLG_MIRROR_PERCENT
@@ -91,7 +90,7 @@ def cam_ucs_to_cam_jmh(ucs: Vector, model: str) -> Vector:
     ]
 
 
-class CAM16UCS(Labish, Space):
+class CAM16UCS(Lab):
     """CAM16 UCS (Jab) class."""
 
     BASE = "cam16-jmh"
@@ -114,7 +113,7 @@ class CAM16UCS(Labish, Space):
         """Check if color is achromatic."""
 
         j, m = cam_ucs_to_cam_jmh(coords, self.MODEL)[:-1]
-        return j == 0 or abs(m) < ACHROMATIC_THRESHOLD
+        return j == 0 or abs(m) < self.achromatic_threshold
 
     def to_base(self, coords: Vector) -> Vector:
         """To CAM16 JMh from CAM16."""

--- a/coloraide/spaces/cmy.py
+++ b/coloraide/spaces/cmy.py
@@ -1,5 +1,6 @@
 """Uncalibrated, naive CMY color space."""
 from __future__ import annotations
+from .. import util
 from ..spaces import Regular, Space
 from ..channels import Channel
 from ..cat import WHITES
@@ -43,7 +44,7 @@ class CMY(Regular, Space):
 
         black = [1, 1, 1]
         for x in alg.vcross(coords, black):
-            if not math.isclose(0.0, x, abs_tol=1e-4):
+            if not math.isclose(0.0, x, abs_tol=util.ACHROMATIC_THRESHOLD_SM):
                 return False
         return True
 

--- a/coloraide/spaces/cmyk.py
+++ b/coloraide/spaces/cmyk.py
@@ -4,6 +4,7 @@ Uncalibrated, naive CMYK color space.
 https://www.w3.org/TR/css-color-5/#cmyk-rgb
 """
 from __future__ import annotations
+from .. import util
 from ..spaces import Space
 from ..channels import Channel
 from ..cat import WHITES
@@ -60,12 +61,12 @@ class CMYK(Space):
     def is_achromatic(self, coords: Vector) -> bool:
         """Test if color is achromatic."""
 
-        if math.isclose(1.0, coords[-1], abs_tol=1e-4):
+        if math.isclose(1.0, coords[-1], abs_tol=util.ACHROMATIC_THRESHOLD_SM):
             return True
 
         black = [1, 1, 1]
         for x in alg.vcross(coords[:-1], black):
-            if not math.isclose(0.0, x, abs_tol=1e-5):
+            if not math.isclose(0.0, x, abs_tol=util.ACHROMATIC_THRESHOLD_SM):
                 return False
         return True
 

--- a/coloraide/spaces/cubehelix.py
+++ b/coloraide/spaces/cubehelix.py
@@ -24,7 +24,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 """
 from __future__ import annotations
-from ..spaces import Space, HSLish
+from . hsl import HSL
 from ..cat import WHITES
 from ..channels import Channel, FLG_ANGLE
 import math
@@ -72,7 +72,7 @@ def cubehelix_to_srgb(coords: Vector) -> Vector:
     ]
 
 
-class Cubehelix(HSLish, Space):
+class Cubehelix(HSL):
     """Cubehelix class."""
 
     BASE = 'srgb'
@@ -103,7 +103,7 @@ class Cubehelix(HSLish, Space):
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
 
-        return abs(coords[1]) < 1e-4 or coords[2] > (1 - 1e-7) or coords[2] < 1e-08
+        return abs(coords[1]) < self.achromatic_threshold or coords[2] > (1 - 1e-7) or coords[2] < 1e-08
 
     def to_base(self, coords: Vector) -> Vector:
         """To LChuv from HSLuv."""

--- a/coloraide/spaces/hct.py
+++ b/coloraide/spaces/hct.py
@@ -38,12 +38,11 @@ color(--hct 256.79 31.766 33.344 / 1)
 """
 from __future__ import annotations
 from .. import algebra as alg
-from ..spaces import Space, LChish
+from .lch import LCh
 from ..cat import WHITES
 from ..channels import Channel, FLG_ANGLE
 from .cam16_jmh import Environment, cam_to_xyz, xyz_to_cam
 from .lab import EPSILON, KAPPA, KE
-from .lch import ACHROMATIC_THRESHOLD
 from ..types import Vector
 import math
 
@@ -156,7 +155,7 @@ def xyz_to_hct(coords: Vector, env: Environment) -> Vector:
     return [h, c, t]
 
 
-class HCT(LChish, Space):
+class HCT(LCh):
     """HCT class."""
 
     BASE = "xyz-d65"
@@ -200,7 +199,7 @@ class HCT(LChish, Space):
         """Check if color is achromatic."""
 
         # Account for both positive and negative chroma
-        return coords[2] == 0 or abs(coords[1]) < ACHROMATIC_THRESHOLD
+        return coords[2] == 0 or abs(coords[1]) < self.achromatic_threshold
 
     def names(self) -> tuple[Channel, ...]:
         """Return LCh-ish names in the order L C h."""

--- a/coloraide/spaces/hpluv.py
+++ b/coloraide/spaces/hpluv.py
@@ -25,7 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 from __future__ import annotations
-from ..spaces import Space, HSLish
+from .hsl import HSL
 from ..cat import WHITES
 from ..channels import Channel, FLG_ANGLE
 from .lab import EPSILON, KAPPA
@@ -103,7 +103,7 @@ def luv_to_hpluv(luv: Vector) -> Vector:
     return [util.constrain_hue(h), s, l]
 
 
-class HPLuv(HSLish, Space):
+class HPLuv(HSL):
     """HPLuv class."""
 
     BASE = 'luv'
@@ -120,6 +120,7 @@ class HPLuv(HSLish, Space):
         "lightness": "l"
     }
     WHITE = WHITES['2deg']['D65']
+    GAMUT_CHECK = None
 
     def normalize(self, coords: Vector) -> Vector:
         """Normalize coordinates."""
@@ -132,7 +133,7 @@ class HPLuv(HSLish, Space):
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
 
-        return abs(coords[1]) < 1e-4 or coords[2] > (100 - 1e-7) or coords[2] < 1e-08
+        return abs(coords[1]) < self.achromatic_threshold or coords[2] > (100 - 1e-7) or coords[2] < 1e-08
 
     def to_base(self, coords: Vector) -> Vector:
         """To LChuv from HPLuv."""

--- a/coloraide/spaces/hsl/__init__.py
+++ b/coloraide/spaces/hsl/__init__.py
@@ -1,10 +1,12 @@
 """HSL class."""
 from __future__ import annotations
+from ... import algebra as alg
 from ...spaces import HSLish, Space
 from ...cat import WHITES
 from ...channels import Channel, FLG_ANGLE
 from ... import util
 from ...types import Vector
+from typing import Any
 
 
 def srgb_to_hsl(rgb: Vector) -> Vector:
@@ -82,6 +84,13 @@ class HSL(HSLish, Space):
     GAMUT_CHECK = "srgb"  # type: str | None
     CLIP_SPACE = "hsl"  # type: str | None
 
+    def __init__(self, **kwargs: Any):
+        """Initialize."""
+
+        super().__init__(**kwargs)
+        order = alg.order(self.channels[self.indexes()[2]].high)
+        self.achromatic_threshold = util.ACHROMATIC_THRESHOLD_SM if order == 0 else util.ACHROMATIC_THRESHOLD
+
     def normalize(self, coords: Vector) -> Vector:
         """Normalize coordinates."""
 
@@ -94,7 +103,11 @@ class HSL(HSLish, Space):
     def is_achromatic(self, coords: Vector) -> bool | None:
         """Check if color is achromatic."""
 
-        return abs(coords[1]) < 1e-4 or coords[2] == 0.0 or abs(1 - coords[2]) < 1e-7
+        return (
+            abs(coords[1]) < self.achromatic_threshold or
+            coords[2] == 0.0 or
+            abs(1 - coords[2]) < self.achromatic_threshold
+        )
 
     def to_base(self, coords: Vector) -> Vector:
         """To sRGB from HSL."""

--- a/coloraide/spaces/hsluv.py
+++ b/coloraide/spaces/hsluv.py
@@ -25,9 +25,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 from __future__ import annotations
-from ..spaces import Space, HSLish
 from ..cat import WHITES
 from ..channels import Channel, FLG_ANGLE
+from .hsl import HSL
 from .lab import EPSILON, KAPPA
 from .srgb_linear import XYZ_TO_RGB
 import math
@@ -106,7 +106,7 @@ def luv_to_hsluv(luv: Vector) -> Vector:
     return [util.constrain_hue(h), s, l]
 
 
-class HSLuv(HSLish, Space):
+class HSLuv(HSL):
     """HSLuv class."""
 
     BASE = 'luv'
@@ -137,7 +137,7 @@ class HSLuv(HSLish, Space):
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
 
-        return abs(coords[1]) < 1e-4 or coords[2] > (100 - 1e-7) or coords[2] < 1e-08
+        return abs(coords[1]) < self.achromatic_threshold or coords[2] > (100 - 1e-7) or coords[2] < 1e-08
 
     def to_base(self, coords: Vector) -> Vector:
         """To LChuv from HSLuv."""

--- a/coloraide/spaces/hsv.py
+++ b/coloraide/spaces/hsv.py
@@ -1,10 +1,12 @@
 """HSV class."""
 from __future__ import annotations
+from .. import algebra as alg
 from ..spaces import Space, HSVish
 from ..cat import WHITES
 from ..channels import Channel, FLG_ANGLE
 from .. import util
 from ..types import Vector
+from typing import Any
 
 
 def hsv_to_srgb(hsv: Vector) -> Vector:
@@ -77,6 +79,13 @@ class HSV(HSVish, Space):
     CLIP_SPACE = "hsv"  # type: str | None
     WHITE = WHITES['2deg']['D65']
 
+    def __init__(self, **kwargs: Any):
+        """Initialize."""
+
+        super().__init__(**kwargs)
+        order = alg.order(self.channels[self.indexes()[2]].high)
+        self.achromatic_threshold = util.ACHROMATIC_THRESHOLD_SM if order == 0 else util.ACHROMATIC_THRESHOLD
+
     def normalize(self, coords: Vector) -> Vector:
         """Normalize coordinates."""
 
@@ -88,7 +97,7 @@ class HSV(HSVish, Space):
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
 
-        return abs(coords[1]) < 1e-5 or coords[2] == 0.0
+        return abs(coords[1]) < self.achromatic_threshold or coords[2] == 0.0
 
     def to_base(self, coords: Vector) -> Vector:
         """To HSL from HSV."""

--- a/coloraide/spaces/jzazbz.py
+++ b/coloraide/spaces/jzazbz.py
@@ -10,7 +10,6 @@ This is confirmed here: https://www.itu.int/dms_pub/itu-r/opb/rep/R-REP-BT.2408-
 If at some time that these assumptions are incorrect, we will be happy to alter the model.
 """
 from __future__ import annotations
-from ..spaces import Space
 from ..cat import WHITES
 from ..channels import Channel, FLG_MIRROR_PERCENT
 from .. import util
@@ -122,7 +121,7 @@ def xyz_to_jzazbz(xyz: Vector) -> Vector:
     return [jz, az, bz]
 
 
-class Jzazbz(Lab, Space):
+class Jzazbz(Lab):
     """Jzazbz class."""
 
     BASE = "xyz-d65"

--- a/coloraide/spaces/lab/__init__.py
+++ b/coloraide/spaces/lab/__init__.py
@@ -9,10 +9,11 @@ from ...spaces import Space, Labish
 from ...cat import WHITES
 from ...channels import Channel, FLG_MIRROR_PERCENT
 from ... import util
+from ... util import ACHROMATIC_THRESHOLD
 from ... import algebra as alg
 from ...types import VectorLike, Vector
+from typing import Any
 
-ACHROMATIC_THRESHOLD = 1e-4
 EPSILON = 216 / 24389  # `6^3 / 29^3`
 EPSILON3 = 6 / 29  # Cube root of EPSILON
 KAPPA = 24389 / 27
@@ -67,10 +68,17 @@ class Lab(Labish, Space):
         "lightness": "l"
     }
 
+    def __init__(self, **kwargs: Any):
+        """Initialize."""
+
+        super().__init__(**kwargs)
+        order = alg.order(self.channels[self.indexes()[0]].high)
+        self.achromatic_threshold = util.ACHROMATIC_THRESHOLD_SM if order == 0 else ACHROMATIC_THRESHOLD
+
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
 
-        return alg.rect_to_polar(coords[1], coords[2])[0] < ACHROMATIC_THRESHOLD
+        return alg.rect_to_polar(coords[1], coords[2])[0] < self.achromatic_threshold
 
     def to_base(self, coords: Vector) -> Vector:
         """To XYZ D50 from Lab."""

--- a/coloraide/spaces/lch/__init__.py
+++ b/coloraide/spaces/lch/__init__.py
@@ -1,13 +1,14 @@
 """LCh class."""
 from __future__ import annotations
+from ... import algebra as alg
 from ...spaces import Space, LChish
 from ...cat import WHITES
 from ...channels import Channel, FLG_ANGLE
 from ... import util
+from ... util import ACHROMATIC_THRESHOLD
 import math
 from ...types import Vector
-
-ACHROMATIC_THRESHOLD = 1e-4
+from typing import Any
 
 
 def lab_to_lch(lab: Vector) -> Vector:
@@ -47,6 +48,13 @@ class LCh(LChish, Space):
         "hue": "h"
     }
 
+    def __init__(self, **kwargs: Any):
+        """Initialize."""
+
+        super().__init__(**kwargs)
+        order = alg.order(self.channels[self.indexes()[0]].high)
+        self.achromatic_threshold = util.ACHROMATIC_THRESHOLD_SM if order == 0 else ACHROMATIC_THRESHOLD
+
     def normalize(self, coords: Vector) -> Vector:
         """Normalize coordinates."""
 
@@ -60,7 +68,7 @@ class LCh(LChish, Space):
         """Check if color is achromatic."""
 
         # Account for both positive and negative chroma
-        return abs(coords[1]) < ACHROMATIC_THRESHOLD
+        return abs(coords[1]) < self.achromatic_threshold
 
     def to_base(self, coords: Vector) -> Vector:
         """To Lab from LCh."""

--- a/coloraide/spaces/lchuv.py
+++ b/coloraide/spaces/lchuv.py
@@ -1,13 +1,12 @@
 """LChuv class."""
 from __future__ import annotations
-from ..spaces import Space
+from .lch import LCh
 from ..cat import WHITES
 from ..channels import Channel, FLG_ANGLE
-from .lch import LCh, ACHROMATIC_THRESHOLD
 from ..types import Vector
 
 
-class LChuv(LCh, Space):
+class LChuv(LCh):
     """LChuv class."""
 
     BASE = "luv"
@@ -23,4 +22,4 @@ class LChuv(LCh, Space):
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
 
-        return coords[0] == 0.0 or coords[1] < ACHROMATIC_THRESHOLD
+        return coords[0] == 0.0 or coords[1] < self.achromatic_threshold

--- a/coloraide/spaces/luv.py
+++ b/coloraide/spaces/luv.py
@@ -4,10 +4,9 @@ Luv class.
 https://en.wikipedia.org/wiki/CIELuv
 """
 from __future__ import annotations
-from ..spaces import Space, Labish
 from ..cat import WHITES
 from ..channels import Channel, FLG_MIRROR_PERCENT
-from .lab import KAPPA, EPSILON, KE, ACHROMATIC_THRESHOLD
+from .lab import KAPPA, EPSILON, KE, Lab
 from .. import util
 from .. import algebra as alg
 from ..types import Vector
@@ -54,7 +53,7 @@ def luv_to_xyz(luv: Vector, white: tuple[float, float]) -> Vector:
     return [x, y, z]
 
 
-class Luv(Labish, Space):
+class Luv(Lab):
     """Luv class."""
 
     BASE = "xyz-d65"
@@ -73,7 +72,7 @@ class Luv(Labish, Space):
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
 
-        return coords[0] == 0.0 or alg.rect_to_polar(coords[1], coords[2])[0] < ACHROMATIC_THRESHOLD
+        return coords[0] == 0.0 or alg.rect_to_polar(coords[1], coords[2])[0] < self.achromatic_threshold
 
     def to_base(self, coords: Vector) -> Vector:
         """To XYZ D50 from Luv."""

--- a/coloraide/spaces/prismatic.py
+++ b/coloraide/spaces/prismatic.py
@@ -7,6 +7,7 @@ http://psgraphics.blogspot.com/2015/10/prismatic-color-model.html
 https://studylib.net/doc/14656976/the-prismatic-color-space-for-rgb-computations
 """
 from __future__ import annotations
+from .. import util
 from ..spaces import Space
 from ..channels import Channel
 from ..cat import WHITES
@@ -58,12 +59,12 @@ class Prismatic(Space):
     def is_achromatic(self, coords: Vector) -> bool:
         """Test if color is achromatic."""
 
-        if math.isclose(0.0, coords[0], abs_tol=1e-4):
+        if math.isclose(0.0, coords[0], abs_tol=util.ACHROMATIC_THRESHOLD_SM):
             return True
 
         white = [1, 1, 1]
         for x in alg.vcross(coords[:-1], white):
-            if not math.isclose(0.0, x, abs_tol=1e-5):
+            if not math.isclose(0.0, x, abs_tol=util.ACHROMATIC_THRESHOLD_SM):
                 return False
         return True
 

--- a/coloraide/spaces/ryb.py
+++ b/coloraide/spaces/ryb.py
@@ -6,6 +6,7 @@ http://bahamas10.github.io/ryb/assets/ryb.pdf
 """
 from __future__ import annotations
 import math
+from .. import util
 from ..spaces import Regular, Space
 from .. import algebra as alg
 from ..channels import Channel
@@ -77,7 +78,7 @@ class RYB(Regular, Space):
 
         coords = self.to_base(coords)
         for x in alg.vcross(coords, [1, 1, 1]):
-            if not math.isclose(0.0, x, abs_tol=1e-5):
+            if not math.isclose(0.0, x, abs_tol=util.ACHROMATIC_THRESHOLD):
                 return False
         return True
 

--- a/coloraide/spaces/srgb_linear.py
+++ b/coloraide/spaces/srgb_linear.py
@@ -1,5 +1,6 @@
 """sRGB Linear color class."""
 from __future__ import annotations
+from .. import util
 from ..cat import WHITES
 from ..spaces import RGBish, Space
 from ..channels import Channel
@@ -59,7 +60,7 @@ class sRGBLinear(RGBish, Space):
 
         white = [1, 1, 1]
         for x in alg.vcross(coords, white):
-            if not math.isclose(0.0, x, abs_tol=1e-5):
+            if not math.isclose(0.0, x, abs_tol=util.ACHROMATIC_THRESHOLD_SM):
                 return False
         return True
 

--- a/coloraide/spaces/xyb.py
+++ b/coloraide/spaces/xyb.py
@@ -5,8 +5,7 @@ https://ds.jpeg.org/whitepapers/jpeg-xl-whitepaper.pdf
 """
 from __future__ import annotations
 from .. import algebra as alg
-from ..spaces import Space, Labish
-from ..spaces.lab import ACHROMATIC_THRESHOLD
+from ..spaces.lab import Lab
 from ..types import Vector
 from ..cat import WHITES
 from ..channels import Channel, FLG_MIRROR_PERCENT
@@ -70,7 +69,7 @@ def xyb_to_rgb(xyb: Vector) -> Vector:
     )
 
 
-class XYB(Labish, Space):
+class XYB(Lab):
     """XYB color class."""
 
     BASE = 'srgb-linear'
@@ -86,7 +85,7 @@ class XYB(Labish, Space):
     def is_achromatic(self, coords: Vector) -> bool:
         """Check if color is achromatic."""
 
-        return alg.rect_to_polar(coords[0], coords[2])[0] < ACHROMATIC_THRESHOLD
+        return alg.rect_to_polar(coords[0], coords[2])[0] < self.achromatic_threshold
 
     def names(self) -> tuple[Channel, ...]:
         """Return Lab-ish names in the order L a b."""

--- a/coloraide/spaces/xyy.py
+++ b/coloraide/spaces/xyy.py
@@ -32,7 +32,7 @@ class xyY(Space):
         if math.isclose(0.0, coords[-1], abs_tol=1e-4):
             return True
 
-        if not math.isclose(0.0, alg.vcross(coords[:-1], self.WHITE), abs_tol=1e-6):
+        if not math.isclose(0.0, alg.vcross(coords[:-1], self.WHITE), abs_tol=util.ACHROMATIC_THRESHOLD_SM):
             return False
         return True
 

--- a/coloraide/spaces/xyz_d65.py
+++ b/coloraide/spaces/xyz_d65.py
@@ -26,7 +26,7 @@ class XYZD65(RGBish, Space):
         """Is achromatic."""
 
         for x in alg.vcross(coords, util.xy_to_xyz(self.white())):
-            if not math.isclose(0.0, x, abs_tol=1e-5):
+            if not math.isclose(0.0, x, abs_tol=util.ACHROMATIC_THRESHOLD_SM):
                 return False
         return True
 

--- a/coloraide/spaces/zcam_jmh.py
+++ b/coloraide/spaces/zcam_jmh.py
@@ -14,11 +14,10 @@ import math
 import bisect
 from .. import util
 from .. import algebra as alg
-from ..spaces import Space
 from ..cat import WHITES
 from ..channels import Channel, FLG_ANGLE
 from ..types import Vector, VectorLike
-from .lch import LCh, ACHROMATIC_THRESHOLD
+from .lch import LCh
 from .jzazbz import izazbz_to_xyz, xyz_to_izazbz
 from .. import cat
 
@@ -379,7 +378,7 @@ def zcam_jmh_to_xyz(jmh: Vector, env: Environment) -> Vector:
     return zcam_to_xyz(Jz=Jz, Mz=Mz, hz=hz, env=env)
 
 
-class ZCAMJMh(LCh, Space):
+class ZCAMJMh(LCh):
     """ZCAM class (JMh)."""
 
     BASE = "xyz-d65"
@@ -430,7 +429,7 @@ class ZCAMJMh(LCh, Space):
         """Check if color is achromatic."""
 
         # Account for both positive and negative chroma
-        return coords[0] == 0 or abs(coords[1]) < ACHROMATIC_THRESHOLD
+        return coords[0] == 0 or abs(coords[1]) < self.achromatic_threshold
 
     def hue_name(self) -> str:
         """Hue name."""

--- a/coloraide/util.py
+++ b/coloraide/util.py
@@ -21,6 +21,9 @@ DEF_CONTRAST = "wcag21"
 DEF_CCT = "robertson-1968"
 DEF_INTERPOLATOR = "linear"
 
+ACHROMATIC_THRESHOLD = 1e-4
+ACHROMATIC_THRESHOLD_SM = 1e-6
+
 # PQ Constants
 # https://en.wikipedia.org/wiki/High-dynamic-range_video#Perceptual_quantizer
 M1 = 2610 / 16384

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,6 +2,8 @@
 
 ## 4.3.1
 
+-   **FIX**: Scale achromatic threshold depending on order of magnitude of component scaling. This ensures colors that
+    are scaled roughly between 0 - 1 are not considered achromatic earlier than a space scaled roughly between 0 - 100.
 -   **FIX**: Optimized matrix math operations should handle column vectors.
 
 ## 4.3

--- a/tests/test_hsl.py
+++ b/tests/test_hsl.py
@@ -216,7 +216,7 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
         self.assertEqual(Color('hsl', [270, 0.5, 0]).is_achromatic(), True)
         self.assertEqual(Color('hsl', [270, 0.5, 1]).is_achromatic(), True)
         self.assertEqual(Color('hsl', [270, 0, 0.5]).is_achromatic(), True)
-        self.assertEqual(Color('hsl', [270, 0.000001, 0.5]).is_achromatic(), True)
+        self.assertEqual(Color('hsl', [270, 0.0000001, 0.5]).is_achromatic(), True)
         self.assertEqual(Color('hsl', [270, 0.5, 0.9999999]).is_achromatic(), True)
         self.assertEqual(Color('hsl', [270, NaN, 0]).is_achromatic(), True)
         self.assertEqual(Color('hsl', [270, NaN, 1]).is_achromatic(), True)

--- a/tests/test_hsv.py
+++ b/tests/test_hsv.py
@@ -164,7 +164,7 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
 
         self.assertEqual(Color('hsv', [270, 0.5, 0]).is_achromatic(), True)
         self.assertEqual(Color('hsv', [270, 0, 0.5]).is_achromatic(), True)
-        self.assertEqual(Color('hsv', [270, 0.000001, 0.5]).is_achromatic(), True)
+        self.assertEqual(Color('hsv', [270, 0.0000001, 0.5]).is_achromatic(), True)
         self.assertEqual(Color('hsv', [270, NaN, 0]).is_achromatic(), True)
         self.assertEqual(Color('hsv', [270, 0.0, NaN]).is_achromatic(), True)
         self.assertEqual(Color('hsv', [270, 0.5, 1]).is_achromatic(), False)

--- a/tests/test_jzczhz.py
+++ b/tests/test_jzczhz.py
@@ -162,10 +162,8 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
     def test_achromatic(self):
         """Test when color is achromatic."""
 
-        self.assertEqual(Color('#222222').convert('jzczhz').is_achromatic(), True)
-        self.assertEqual(Color('#222222').convert('jzczhz').set('cz', lambda c: c + 1e-8).is_achromatic(), True)
         self.assertEqual(
-            Color('#222222').convert('jzczhz').set('cz', lambda c: -c).set('h', lambda h: h + 180).is_achromatic(),
+            Color('srgb', [0.000000001] * 3).convert('jzczhz').set('c', lambda x: x + 1e-8).is_achromatic(),
             True
         )
         self.assertEqual(Color('jzczhz', [NaN, 0.0, 270]).is_achromatic(), True)

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -137,8 +137,8 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
         """Test when color is achromatic."""
 
         self.assertEqual(Color('lab', [30, 0, 0]).is_achromatic(), True)
-        self.assertEqual(Color('lab', [30, 0.000001, 0]).is_achromatic(), True)
-        self.assertEqual(Color('lab', [NaN, 0.00001, 0]).is_achromatic(), True)
+        self.assertEqual(Color('lab', [30, 0.0000001, 0]).is_achromatic(), True)
+        self.assertEqual(Color('lab', [NaN, 0.0000001, 0]).is_achromatic(), True)
         self.assertEqual(Color('lab', [0, NaN, NaN]).is_achromatic(), True)
         self.assertEqual(Color('lab', [0, NaN, NaN]).is_achromatic(), True)
         self.assertEqual(Color('lab', [0, 30, -40]).is_achromatic(), False)

--- a/tests/test_lch.py
+++ b/tests/test_lch.py
@@ -209,8 +209,8 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
         """Test when color is achromatic."""
 
         self.assertEqual(Color('lch', [30, 0, 270]).is_achromatic(), True)
-        self.assertEqual(Color('lch', [30, 0.000001, 270]).is_achromatic(), True)
-        self.assertEqual(Color('lch', [NaN, 0.00001, 270]).is_achromatic(), True)
+        self.assertEqual(Color('lch', [30, 0.0000001, 270]).is_achromatic(), True)
+        self.assertEqual(Color('lch', [NaN, 0.0000001, 270]).is_achromatic(), True)
         self.assertEqual(Color('lch', [0, NaN, 270]).is_achromatic(), True)
         self.assertEqual(Color('lch', [0, 100, 270]).is_achromatic(), False)
         self.assertEqual(Color('lch', [NaN, 20, 270]).is_achromatic(), False)

--- a/tests/test_lchuv.py
+++ b/tests/test_lchuv.py
@@ -167,8 +167,8 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
         """Test when color is achromatic."""
 
         self.assertEqual(Color('lchuv', [30, 0, 270]).is_achromatic(), True)
-        self.assertEqual(Color('lchuv', [30, 0.000001, 270]).is_achromatic(), True)
-        self.assertEqual(Color('lchuv', [NaN, 0.00001, 270]).is_achromatic(), True)
+        self.assertEqual(Color('lchuv', [30, 0.0000001, 270]).is_achromatic(), True)
+        self.assertEqual(Color('lchuv', [NaN, 0.0000001, 270]).is_achromatic(), True)
         self.assertEqual(Color('lchuv', [0, NaN, 270]).is_achromatic(), True)
         self.assertEqual(Color('lchuv', [0, 100, 270]).is_achromatic(), True)
         self.assertEqual(Color('lchuv', [NaN, 20, 270]).is_achromatic(), True)

--- a/tests/test_luv.py
+++ b/tests/test_luv.py
@@ -104,8 +104,8 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
         """Test when color is achromatic."""
 
         self.assertEqual(Color('luv', [30, 0, 0]).is_achromatic(), True)
-        self.assertEqual(Color('luv', [30, 0.000001, 0]).is_achromatic(), True)
-        self.assertEqual(Color('luv', [NaN, 0.00001, 0]).is_achromatic(), True)
+        self.assertEqual(Color('luv', [30, 0.0000001, 0]).is_achromatic(), True)
+        self.assertEqual(Color('luv', [NaN, 0.0000001, 0]).is_achromatic(), True)
         self.assertEqual(Color('luv', [0, NaN, NaN]).is_achromatic(), True)
         self.assertEqual(Color('luv', [0, 30, -40]).is_achromatic(), True)
         self.assertEqual(Color('luv', [NaN, 0, -30]).is_achromatic(), True)

--- a/tests/test_okhsv.py
+++ b/tests/test_okhsv.py
@@ -140,7 +140,7 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
 
         self.assertEqual(Color('okhsv', [270, 0.5, 0]).is_achromatic(), True)
         self.assertEqual(Color('okhsv', [270, 0, 0.5]).is_achromatic(), True)
-        self.assertEqual(Color('okhsv', [270, 0.000001, 0.5]).is_achromatic(), True)
+        self.assertEqual(Color('okhsv', [270, 0.0000001, 0.5]).is_achromatic(), True)
         self.assertEqual(Color('okhsv', [270, NaN, 0]).is_achromatic(), True)
         self.assertEqual(Color('okhsv', [270, 0.0, NaN]).is_achromatic(), True)
         self.assertEqual(Color('okhsv', [270, 0.5, 1]).is_achromatic(), False)

--- a/tests/test_oklab.py
+++ b/tests/test_oklab.py
@@ -126,8 +126,8 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
 
         self.assertEqual(Color('oklab', [0.3, 0, 0]).is_achromatic(), True)
         self.assertEqual(Color('oklab', [-0.3, 0, 0]).is_achromatic(), True)
-        self.assertEqual(Color('oklab', [0.3, 0.000001, 0]).is_achromatic(), True)
-        self.assertEqual(Color('oklab', [NaN, 0.00001, 0]).is_achromatic(), True)
+        self.assertEqual(Color('oklab', [0.3, 0.0000001, 0]).is_achromatic(), True)
+        self.assertEqual(Color('oklab', [NaN, 0.0000001, 0]).is_achromatic(), True)
         self.assertEqual(Color('oklab', [0, NaN, NaN]).is_achromatic(), True)
         self.assertEqual(Color('oklab', [0, NaN, NaN]).is_achromatic(), True)
         self.assertEqual(Color('oklab', [0, 0.3, -0.4]).is_achromatic(), False)

--- a/tests/test_oklch.py
+++ b/tests/test_oklch.py
@@ -194,8 +194,8 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
         """Test when color is achromatic."""
 
         self.assertEqual(Color('oklch', [0.3, 0, 270]).is_achromatic(), True)
-        self.assertEqual(Color('oklch', [0.3, 0.000001, 270]).is_achromatic(), True)
-        self.assertEqual(Color('oklch', [NaN, 0.00001, 270]).is_achromatic(), True)
+        self.assertEqual(Color('oklch', [0.3, 0.0000001, 270]).is_achromatic(), True)
+        self.assertEqual(Color('oklch', [NaN, 0.0000001, 270]).is_achromatic(), True)
         self.assertEqual(Color('oklch', [0, NaN, 270]).is_achromatic(), True)
         self.assertEqual(Color('oklch', [0, 1, 270]).is_achromatic(), False)
         self.assertEqual(Color('oklch', [NaN, 0.2, 270]).is_achromatic(), False)

--- a/tests/test_oklrab.py
+++ b/tests/test_oklrab.py
@@ -120,8 +120,8 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
 
         self.assertEqual(Color('oklrab', [0.3, 0, 0]).is_achromatic(), True)
         self.assertEqual(Color('oklrab', [-0.3, 0, 0]).is_achromatic(), True)
-        self.assertEqual(Color('oklrab', [0.3, 0.000001, 0]).is_achromatic(), True)
-        self.assertEqual(Color('oklrab', [NaN, 0.00001, 0]).is_achromatic(), True)
+        self.assertEqual(Color('oklrab', [0.3, 0.0000001, 0]).is_achromatic(), True)
+        self.assertEqual(Color('oklrab', [NaN, 0.0000001, 0]).is_achromatic(), True)
         self.assertEqual(Color('oklrab', [0, NaN, NaN]).is_achromatic(), True)
         self.assertEqual(Color('oklrab', [0, NaN, NaN]).is_achromatic(), True)
         self.assertEqual(Color('oklrab', [0, 0.3, -0.4]).is_achromatic(), False)

--- a/tests/test_oklrch.py
+++ b/tests/test_oklrch.py
@@ -174,8 +174,8 @@ class TestsAchromatic(util.ColorAsserts, unittest.TestCase):
         """Test when color is achromatic."""
 
         self.assertEqual(Color('oklrch', [0.3, 0, 270]).is_achromatic(), True)
-        self.assertEqual(Color('oklrch', [0.3, 0.000001, 270]).is_achromatic(), True)
-        self.assertEqual(Color('oklrch', [NaN, 0.00001, 270]).is_achromatic(), True)
+        self.assertEqual(Color('oklrch', [0.3, 0.0000001, 270]).is_achromatic(), True)
+        self.assertEqual(Color('oklrch', [NaN, 0.0000001, 270]).is_achromatic(), True)
         self.assertEqual(Color('oklrch', [0, NaN, 270]).is_achromatic(), True)
         self.assertEqual(Color('oklrch', [0, 1, 270]).is_achromatic(), False)
         self.assertEqual(Color('oklrch', [NaN, 0.2, 270]).is_achromatic(), False)


### PR DESCRIPTION
Spaces that are scaled on an order of magnitude of 1 should not have the same threshold of a space scaled at an order of magnitude of 100. If they are, this can cause colors to be considered achromatic much earlier if they are scaled small.