### PR TITLE
Use forward referencing for array types

### DIFF
--- a/coloraide/algebra.py
+++ b/coloraide/algebra.py
@@ -18,6 +18,7 @@ There is no requirement that external plugins need to use `algebra` and Numpy an
 used as long as the final results are converted to normal types.
 """
 from __future__ import annotations
+import builtins
 import decimal
 import sys
 import cmath
@@ -43,8 +44,8 @@ MIN_FLOAT = sys.float_info.min
 
 # Keeping for backwards compatibility
 prod = math.prod
-_all = all
-_any = any
+_all = builtins.all
+_any = builtins.any
 
 # Shortcut for math operations
 # Specify one of these in divide, multiply, dot, etc.
@@ -3753,7 +3754,7 @@ def lu(
             size = s[1]
             wide = True
             for _ in range(diff):
-                matrix.append([0.0] * size)  # type: ignore[list-item]  # noqa: PERF401
+                matrix.append([0.0] * size)  # type: ignore[arg-type]  # noqa: PERF401
         # Tall
         else:
             tall = True

--- a/coloraide/types.py
+++ b/coloraide/types.py
@@ -19,24 +19,24 @@ ColorInput = Union['Color', str, Mapping[str, Any]]
 # Vectors, Matrices, and Arrays are assumed to be mutable lists
 Vector = List[float]
 Matrix = List[Vector]
-Tensor = List[List[List[Union[float, Any]]]]
+Tensor = List[Union[Matrix, 'Tensor']]
 Array = Union[Matrix, Vector, Tensor]
 
 # Anything that resembles a sequence will be considered "like" one of our types above
 VectorLike = Sequence[float]
 MatrixLike = Sequence[VectorLike]
-TensorLike = Sequence[Sequence[Sequence[Union[float, Any]]]]
+TensorLike = Sequence[Union[MatrixLike, 'TensorLike']]
 ArrayLike = Union[VectorLike, MatrixLike, TensorLike]
 
 # Vectors, Matrices, and Arrays of various, specific types
 VectorBool = List[bool]
 MatrixBool = List[VectorBool]
-TensorBool = List[List[List[Union[bool, Any]]]]
+TensorBool = List[Union[MatrixBool, 'TensorBool']]
 ArrayBool = Union[MatrixBool, VectorBool, TensorBool]
 
 VectorInt = List[int]
 MatrixInt = List[VectorInt]
-TensorInt = List[List[List[Union[int, Any]]]]
+TensorInt = List[Union[MatrixInt, 'TensorInt']]
 ArrayInt = Union[MatrixInt, VectorInt, TensorInt]
 
 # General algebra types


### PR DESCRIPTION
This used to not work with mypy, but now it seems to be working. This is a cleaner, better approach.

Related #375