### PR TITLE
Adjust conversion logic to assume no chroma for undefined hues

### DIFF
--- a/coloraide/color.py
+++ b/coloraide/color.py
@@ -587,12 +587,14 @@ class Color(metaclass=ColorMeta):
     def normalize(self, *, nans: bool = True) -> Self:
         """Normalize the color."""
 
-        self[:-1] = self._space.normalize(self.coords(nans=False))
-        if nans and self._space.is_polar() and self.is_achromatic():
-            i = self._space.hue_index()  # type: ignore[attr-defined]
+        space = self._space
+        coords = space.powerless(self[:-1])
+        self[:-1] = space.normalize([space.resolve_channel(i, coords) for i in range(len(coords))])
+        if math.isnan(self[-1]):
+            self[-1] = 0
+        if nans and space.is_polar() and self.is_achromatic():
+            i = space.hue_index()  # type: ignore[attr-defined]
             self[i] = math.nan
-        alpha = self[-1]
-        self[-1] = 0.0 if math.isnan(alpha) else alpha
         return self
 
     def is_nan(self, name: str) -> bool:  # pragma: no cover
@@ -1623,10 +1625,8 @@ class Color(metaclass=ColorMeta):
             if nans:
                 return self[:-1]
             else:
-                return [
-                    self._space.resolve_channel(index, self._coords)
-                    for index in range(len(self._coords) - 1)
-                ]
+                coords = self._coords
+                return [self._space.resolve_channel(i, coords) for i in range(len(coords) - 1)]
 
         pint = isinstance(precision, int)
         if rounding is None:
@@ -1634,11 +1634,11 @@ class Color(metaclass=ColorMeta):
 
         return [
             alg.round_to(
-                self[index] if nans else self._space.resolve_channel(index, self._coords),
-                precision if pint else util.get_index(precision, index, self.PRECISION),  # type: ignore[arg-type]
+                self[i] if nans else self._space.resolve_channel(i, self._coords),
+                precision if pint else util.get_index(precision, i, self.PRECISION),  # type: ignore[arg-type]
                 rounding
             )
-            for index in range(len(self._coords) - 1)
+            for i in range(len(self._coords) - 1)
         ]
 
     def alpha(

--- a/coloraide/convert.py
+++ b/coloraide/convert.py
@@ -141,7 +141,7 @@ def convert(color: Color, space: str) -> tuple[Space, Vector]:
     # Get coordinates and convert NaN values to 0
     coords = color.coords(nans=False)
 
-    # CSS requires chroma to be zero of hue is undefined.
+    # CSS requires chroma to be zero if hue is undefined.
     if null_hue:
         idx = last.radial_index()  # type: ignore[attr-defined]
         coords[idx] = last.channels[idx].nans

--- a/coloraide/convert.py
+++ b/coloraide/convert.py
@@ -1,5 +1,6 @@
 """Convert the color."""
 from __future__ import annotations
+import math
 from .types import Vector
 from typing import TYPE_CHECKING
 
@@ -125,13 +126,26 @@ def convert(color: Color, space: str) -> tuple[Space, Vector]:
     # Grab the convert for the current space to the desired space
     # Result is cached for quicker future conversions.
     chain = color._get_convert_chain(color._space, space)  # type: ignore[attr-defined]
+    last = color._space
+
+    # Determine if hue is undefined
+    null_hue = False
+    if (
+        last.is_polar() and last.radial_is_colorfulness() and math.isnan(color[last.hue_index()]) and  # type: ignore[attr-defined]
+        not color.is_achromatic()
+    ):
+        null_hue = True
 
     # Get coordinates and convert NaN values to 0
     coords = color.coords(nans=False)
 
+    # CSS requires chroma to be zero of hue is undefined.
+    if null_hue:
+        idx = last.radial_index()  # type: ignore[attr-defined]
+        coords[idx] = last.channels[idx].nans
+
     # Navigate the conversion chain translating the coordinates along the way.
     # Perform chromatic adaption if needed (a conversion to or from XYZ D65).
-    last = color._space
     for a, b, direction, adapt in chain:
         if direction and adapt:
             coords = color.chromatic_adaptation(

--- a/coloraide/convert.py
+++ b/coloraide/convert.py
@@ -128,7 +128,9 @@ def convert(color: Color, space: str) -> tuple[Space, Vector]:
     chain = color._get_convert_chain(color._space, space)  # type: ignore[attr-defined]
     last = color._space
 
-    # Determine if hue is undefined
+    # Determine if hue is undefined. We only care if the color is not considered achromatic already
+    # as adjusting chroma can affect round trip precision. If hue is undefined and the color is not
+    # achromatic, make it achromatic.
     null_hue = False
     if (
         last.is_polar() and last.radial_is_colorfulness() and math.isnan(color[last.hue_index()]) and  # type: ignore[attr-defined]

--- a/coloraide/convert.py
+++ b/coloraide/convert.py
@@ -133,7 +133,8 @@ def convert(color: Color, space: str) -> tuple[Space, Vector]:
     # achromatic, make it achromatic.
     null_hue = False
     if (
-        last.is_polar() and last.radial_is_colorfulness() and math.isnan(color[last.hue_index()]) and  # type: ignore[attr-defined]
+        last.is_polar() and
+        last.radial_is_colorfulness() and  math.isnan(color[last.hue_index()]) and  # type: ignore[attr-defined]
         not color.is_achromatic()
     ):
         null_hue = True

--- a/coloraide/convert.py
+++ b/coloraide/convert.py
@@ -1,6 +1,5 @@
 """Convert the color."""
 from __future__ import annotations
-import math
 from .types import Vector
 from typing import TYPE_CHECKING
 
@@ -128,24 +127,12 @@ def convert(color: Color, space: str) -> tuple[Space, Vector]:
     chain = color._get_convert_chain(color._space, space)  # type: ignore[attr-defined]
     last = color._space
 
-    # Determine if hue is undefined. We only care if the color is not considered achromatic already
-    # as adjusting chroma can affect round trip precision. If hue is undefined and the color is not
-    # achromatic, make it achromatic.
-    null_hue = False
-    if (
-        last.is_polar() and
-        last.radial_is_colorfulness() and  math.isnan(color[last.hue_index()]) and  # type: ignore[attr-defined]
-        not color.is_achromatic()
-    ):
-        null_hue = True
-
-    # Get coordinates and convert NaN values to 0
-    coords = color.coords(nans=False)
-
-    # CSS requires chroma to be zero if hue is undefined.
-    if null_hue:
-        idx = last.radial_index()  # type: ignore[attr-defined]
-        coords[idx] = last.channels[idx].nans
+    coords = color[:-1]
+    # Determine channels for powerlessness. Usually when hue is undefined, we should treat
+    # the chroma channel as zero.
+    coords = last.powerless(coords)
+    # Get coordinates and convert NaN to real values
+    coords[:] = [last.resolve_channel(i, coords) for i in range(len(coords))]
 
     # Navigate the conversion chain translating the coordinates along the way.
     # Perform chromatic adaption if needed (a conversion to or from XYZ D65).

--- a/coloraide/spaces/__init__.py
+++ b/coloraide/spaces/__init__.py
@@ -39,7 +39,7 @@ class Cylindrical:
 
     get_channel_index: Callable[[str], int]
 
-    def radial_is_colorfulness(self) -> bool:
+    def is_radial_colorfulness(self) -> bool:
         """
         Test if radial channel is also the colorfulness channel.
 
@@ -96,6 +96,16 @@ class HSVish(Luminant, Cylindrical):
 
 class HWBish(Cylindrical):
     """HWB-ish space."""
+
+    def is_radial_colorfulness(self) -> bool:
+        """
+        Test if radial channel is also the colorfulness channel.
+
+        There are some spaces, like HWB, which may encode other info in the radial channel making it
+        something different than colorfulness/saturation/chroma.
+        """
+
+        return False
 
     def radial_name(self) -> str:
         """Radial name."""

--- a/coloraide/spaces/__init__.py
+++ b/coloraide/spaces/__init__.py
@@ -224,7 +224,7 @@ class Space(Plugin, metaclass=SpaceMeta):
         return coords
 
     def powerless(self, coords: Vector) -> Vector:
-        """Adjust color channels based on powerless ruless."""
+        """Adjust color channels based on powerless rules."""
 
         return coords
 

--- a/coloraide/spaces/__init__.py
+++ b/coloraide/spaces/__init__.py
@@ -223,6 +223,11 @@ class Space(Plugin, metaclass=SpaceMeta):
 
         return coords
 
+    def powerless(self, coords: Vector) -> Vector:
+        """Adjust color channels based on powerless ruless."""
+
+        return coords
+
     def is_achromatic(self, coords: Vector) -> bool | None:  # pragma: no cover
         """Check if color is achromatic."""
 

--- a/coloraide/spaces/__init__.py
+++ b/coloraide/spaces/__init__.py
@@ -39,6 +39,16 @@ class Cylindrical:
 
     get_channel_index: Callable[[str], int]
 
+    def radial_is_colorfulness(self) -> bool:
+        """
+        Test if radial channel is also the colorfulness channel.
+
+        There are some spaces, like HWB, which may encode other info in the radial channel making it
+        something different than colorfulness/saturation/chroma.
+        """
+
+        return True
+
     def radial_name(self) -> str:
         """Radial name."""
 

--- a/coloraide/spaces/hsl/__init__.py
+++ b/coloraide/spaces/hsl/__init__.py
@@ -1,5 +1,6 @@
 """HSL class."""
 from __future__ import annotations
+import math
 from ... import algebra as alg
 from .. import HSLish, Space
 from ...cat import WHITES
@@ -108,6 +109,15 @@ class HSL(HSLish, Space):
             coords[2] == 0.0 or
             abs(1 - coords[2]) < self.achromatic_threshold
         )
+
+    def powerless(self, coords: Vector) -> Vector:
+        """Adjust color channels based on powerless ruless."""
+
+        if math.isnan(coords[0]):
+            if not self.is_achromatic([self.resolve_channel(i, coords) for i in range(3)]):
+                coords[1] = 0
+
+        return coords
 
     def to_base(self, coords: Vector) -> Vector:
         """To sRGB from HSL."""

--- a/coloraide/spaces/hsl/__init__.py
+++ b/coloraide/spaces/hsl/__init__.py
@@ -111,7 +111,7 @@ class HSL(HSLish, Space):
         )
 
     def powerless(self, coords: Vector) -> Vector:
-        """Adjust color channels based on powerless ruless."""
+        """Adjust color channels based on powerless rules."""
 
         if math.isnan(coords[0]):
             if not self.is_achromatic([self.resolve_channel(i, coords) for i in range(3)]):

--- a/coloraide/spaces/hsv.py
+++ b/coloraide/spaces/hsv.py
@@ -1,5 +1,6 @@
 """HSV class."""
 from __future__ import annotations
+import math
 from .. import algebra as alg
 from . import Space, HSVish
 from ..cat import WHITES
@@ -103,6 +104,16 @@ class HSV(HSVish, Space):
         """Check if color is achromatic."""
 
         return abs(coords[1]) < self.achromatic_threshold or coords[2] == 0.0
+
+    def powerless(self, coords: Vector) -> Vector:
+        """Adjust color channels based on powerless ruless."""
+
+        if math.isnan(coords[0]):
+            if not self.is_achromatic([self.resolve_channel(i, coords) for i in range(3)]):
+                if not math.isnan(coords[1]):
+                    coords[1] = 0
+
+        return coords
 
     def to_base(self, coords: Vector) -> Vector:
         """To HSL from HSV."""

--- a/coloraide/spaces/hsv.py
+++ b/coloraide/spaces/hsv.py
@@ -106,7 +106,7 @@ class HSV(HSVish, Space):
         return abs(coords[1]) < self.achromatic_threshold or coords[2] == 0.0
 
     def powerless(self, coords: Vector) -> Vector:
-        """Adjust color channels based on powerless ruless."""
+        """Adjust color channels based on powerless rules."""
 
         if math.isnan(coords[0]):
             if not self.is_achromatic([self.resolve_channel(i, coords) for i in range(3)]):

--- a/coloraide/spaces/lch/__init__.py
+++ b/coloraide/spaces/lch/__init__.py
@@ -70,7 +70,7 @@ class LCh(LChish, Space):
         return abs(coords[1]) < self.achromatic_threshold
 
     def powerless(self, coords: Vector) -> Vector:
-        """Adjust color channels based on powerless ruless."""
+        """Adjust color channels based on powerless rules."""
 
         if math.isnan(coords[2]):
             if not self.is_achromatic([self.resolve_channel(i, coords) for i in range(3)]):

--- a/coloraide/spaces/lch/__init__.py
+++ b/coloraide/spaces/lch/__init__.py
@@ -69,6 +69,16 @@ class LCh(LChish, Space):
         # Account for both positive and negative chroma
         return abs(coords[1]) < self.achromatic_threshold
 
+    def powerless(self, coords: Vector) -> Vector:
+        """Adjust color channels based on powerless ruless."""
+
+        if math.isnan(coords[2]):
+            if not self.is_achromatic([self.resolve_channel(i, coords) for i in range(3)]):
+                if not math.isnan(coords[1]):
+                    coords[1] = 0
+
+        return coords
+
     def to_base(self, coords: Vector) -> Vector:
         """To Lab from LCh."""
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -6,6 +6,7 @@ icon: lucide/scroll-text
 ## 8.11
 
 -   **NEW**: Add a faster non-cached path for `oklch-cubic` that is optimized for when caching is disabled.
+-   **NEW**: When hue is undefined, and a color is not achromatic, it will be treated as achromatic during conversion.
 
 ## 8.10
 

--- a/docs/src/markdown/plugins/space.md
+++ b/docs/src/markdown/plugins/space.md
@@ -294,6 +294,16 @@ more of the following mixins.
 class Cylindrical:
     """Cylindrical space."""
 
+    def is_radial_colorfulness(self) -> bool:
+        """
+        Test if radial channel is also the colorfulness channel.
+
+        There are some spaces, like HWB, which may encode other info in the radial channel making it
+        something different than colorfulness/saturation/chroma.
+        """
+
+        return True
+
     def radial_name(self) -> str:
         """Radial name."""
 
@@ -366,6 +376,16 @@ class HSVish(Luminant, Cylindrical):
 ```py
 class HWBish(Cylindrical):
     """HWB-ish space."""
+
+    def is_radial_colorfulness(self) -> bool:
+        """
+        Test if radial channel is also the colorfulness channel.
+
+        There are some spaces, like HWB, which may encode other info in the radial channel making it
+        something different than colorfulness/saturation/chroma.
+        """
+
+        return False
 
     def radial_name(self) -> str:
         """Radial name."""

--- a/tests/test_hsl.py
+++ b/tests/test_hsl.py
@@ -126,6 +126,12 @@ class TestHSLSerialize(util.ColorAssertsPyTest):
 class TestHSLProperties(util.ColorAsserts, unittest.TestCase):
     """Test HSL."""
 
+    def test_radial_colorfulness(self):
+        """Test if radial channel is colorfulness."""
+
+        c = Color('color(--hsl 120 50% 90% / 1)')
+        self.assertTrue(c._space.is_radial_colorfulness())
+
     def test_names(self):
         """Test HSL-ish names."""
 

--- a/tests/test_hwb.py
+++ b/tests/test_hwb.py
@@ -87,6 +87,12 @@ class TestHWBSerialize(util.ColorAssertsPyTest):
 class TestHWBProperties(util.ColorAsserts, unittest.TestCase):
     """Test HWB."""
 
+    def test_radial_colorfulness(self):
+        """Test if radial channel is colorfulness."""
+
+        c = Color('color(--hwb 120 50% 90% / 1)')
+        self.assertFalse(c._space.is_radial_colorfulness())
+
     def test_names(self):
         """Test HWB-ish names."""
 


### PR DESCRIPTION
Colors are currently normalized into defined values then passed through a chain of color conversions until the color arrives at the target space. To avoid having to pass undefined values to every space in the chain requiring each space to resolve the undefined values, this approach keeps this logic at the top level of the convert function and applies the chroma hue normalization as the first, initial step before iterating the conversions in the color chain. This keeps the logic generic and requires no modification of every color space.

Resolves #484