### PR TITLE
Add a fast path for Ray Trace with OkLCh and linear RGB gamut mapping

### DIFF
--- a/coloraide/gamut/fit_raytrace.py
+++ b/coloraide/gamut/fit_raytrace.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import math
 from .. import util
 from .. import algebra as alg
-from . import Fit, clip_channels, coerce_to_rgb
+from . import Fit, coerce_to_rgb
 from ..spaces import Prism, Luminant
 from ..cat import WHITES
 from .tools import adaptive_hue_independent
@@ -142,7 +142,6 @@ class RayTrace(Fit):
 
         if pspace is None:
             pspace = self.PSPACE
-        orig_space = space
         cs = color.CS_MAP[space]
 
         # Requires an RGB-ish or Prism space, preferably a linear space.
@@ -191,14 +190,11 @@ class RayTrace(Fit):
         # chroma by the max lightness to get lightness between 0 and 1.
         if adaptive:
             max_light = color.new('xyz-d65', WHITE).convert(pspace, in_place=True)[l]
-            alight = adaptive_hue_independent(
+            achroma[l] = adaptive_hue_independent(
                 mapcolor[l] / max_light,
                 max(mapcolor[c] if polar else alg.rect_to_polar(mapcolor[a], mapcolor[b])[0], 0) / max_light,
                 adaptive
             ) * max_light
-            achroma[l] = alight
-        else:
-            alight = mapcolor[l]
 
         # Some perceptual spaces, such as CAM16 or HCT, may compensate for adapting
         # luminance which may give an achromatic that is not quite achromatic.
@@ -275,5 +271,8 @@ class RayTrace(Fit):
                     continue
 
             # Remove noise from floating point conversion.
-            clip_channels(mapcolor.convert(orig_space, in_place=True))
+            if coerced:
+                mapcolor[:-1] = cs.to_base([max(mn, min(mx, x)) for x in cs.from_base(mapcolor[:-1])])
+            else:
+                mapcolor[:-1] = [max(mn, min(mx, x)) for x in mapcolor[:-1]]
             color.update(mapcolor)

--- a/coloraide/gamut/fit_raytrace.py
+++ b/coloraide/gamut/fit_raytrace.py
@@ -5,19 +5,23 @@ This employs a faster approach than bisecting to reduce chroma.
 """
 from __future__ import annotations
 import math
+from functools import lru_cache
 from .. import util
 from .. import algebra as alg
 from . import Fit, coerce_to_rgb
-from ..spaces import Prism, Luminant
-from ..cat import WHITES
 from .tools import adaptive_hue_independent
-from ..types import Vector, VectorLike
+from ..spaces import Space, Prism, Luminant
+from ..spaces.oklab import LMS_TO_XYZD65, OKLAB_TO_LMS3, LMS3_TO_OKLAB
+from ..cat import WHITES, calc_adaptation_matrices, Bradford, CAT, VonKries
+from ..types import Vector, VectorLike, Matrix
 from typing import Any, TYPE_CHECKING  # noqa: F401
 
 if TYPE_CHECKING:  #pragma: no cover
     from ..color import Color
 
 WHITE = util.xy_to_xyz(WHITES['2deg']['D65'])
+CSS_FAST_PATH = {'oklab', 'oklch'}
+TO_RGB = 'TO_RGB'
 
 
 def to_rect(coords: Vector, c:int, h: int) -> Vector:
@@ -32,6 +36,50 @@ def to_polar(coords: Vector, c:int, h: int) -> Vector:
 
     coords[c], coords[h] = alg.rect_to_polar(coords[c], coords[h])
     return coords
+
+
+@lru_cache(maxsize=10)
+def get_conversion_matrices(name: str, space: Space, cat: str, adapt: CAT) -> tuple[Matrix, Matrix]:
+    """Get and cache conversion matrices to convert from linear RGB to LMS (Oklab variant)."""
+
+    # If we were ever to allow more complicated chromatic adaptation plugins,
+    # we may need to default to Bradford as others may not be compatible.
+    am = Bradford.MATRIX if not isinstance(adapt, VonKries) else adapt.MATRIX
+
+    d65 = WHITES['2deg']['D65']
+    m = space.TO_RGB  # type: ignore[attr-defined]
+    if space.WHITE != d65:
+        m = alg.matmul_x3(
+            m,
+            calc_adaptation_matrices(d65, space.WHITE, am),
+            dims=alg.D2
+        )
+    m = alg.matmul_x3(m, LMS_TO_XYZD65, dims=alg.D2)
+    return m, alg.inv(m)
+
+
+def from_oklch(coords: Vector, m: Matrix) -> Vector:
+    """Specialized conversion from OkLCh going straight from OkLCh to any linear RGB."""
+
+    return alg.matmul_x3(
+        m,
+        [c ** 3 for c in alg.matmul_x3(OKLAB_TO_LMS3, to_rect(coords[:], 1, 2), dims=alg.D2_D1)],
+        dims=alg.D2_D1
+    )
+
+
+def to_oklch(coords: Vector, m: Matrix) -> Vector:
+    """Specialized conversion to OkLCh going straight from any linear RGB to OkLCh."""
+
+    return to_polar(
+        alg.matmul_x3(
+            LMS3_TO_OKLAB,
+            [alg.nth_root(c, 3) for c in alg.matmul_x3(m, coords[:], dims=alg.D2_D1)],
+            dims=alg.D2_D1
+        ),
+        1,
+        2
+    )
 
 
 def project_onto(a: Vector, b: Vector, o: Vector) -> Vector:
@@ -92,6 +140,8 @@ def raytrace_box(
         bx = bmax[i]
 
         # Non parallel case
+        # 64-bit uses a threshold of 1e-12
+        # 32-bit should use 1e-6
         if abs(d) > alg.ATOL:
             inv_d = 1.0 / d
             t1 = (bn - a) * inv_d
@@ -123,6 +173,252 @@ def raytrace_box(
     ]
 
 
+def css_fast_path(
+    color: Color,
+    cs: Space,
+    pspace: str,
+    adaptive: float,
+    mn: float,
+    mx: float,
+    **kwargs: Any
+) -> None:
+    """Path that optimizes conversions for CSS defaults of an Oklab/OkLCh perceptual space and linear RGB target."""
+
+    # RGB linear space
+    rspace = cs.NAME
+
+    # Set the minimum bounds
+    bmax = [mx] * 3
+    bmin = [mn] * 3
+
+    # Ensure we are in the proper perceptual space or normalize values
+    orig = color.space()
+    mapcolor = color.convert(pspace, norm=False) if orig != pspace else color.clone().normalize(nans=False)
+    mapcoords = mapcolor[:-1]
+
+    # Ensure we are working in OkLCh and
+    if pspace == 'oklab':
+        to_polar(mapcoords, 1, 2)
+
+    # Get Oklab conversion matrices from linear RGB -> Oklab LMS
+    adapt = color.CHROMATIC_ADAPTATION
+    m, mi = get_conversion_matrices(rspace, cs, adapt, color.CAT_MAP[adapt])
+
+    # Calculate the achromatic version of the color
+    achroma = mapcoords[:]
+    achroma[1] = 0.0
+
+    # If value is provided for adaptive lightness, calculate a lightness
+    # anchor point relative to the hue independent mid point. Scale lightness and
+    # chroma by the max lightness to get lightness between 0 and 1.
+    if adaptive:
+        max_light = color.new('xyz-d65', WHITE).convert(pspace, in_place=True)[0]
+        achroma[0] = adaptive_hue_independent(
+            mapcoords[0] / max_light,
+            max(mapcoords[1], 0) / max_light,
+            adaptive
+        ) * max_light
+
+    # Calculate achromatic anchor.
+    anchor = from_oklch(achroma, m)
+    # This allows us to find the maximum lightness for HDR RGB and SDR RGB.
+    # Some perceptual spaces do not have a traditional achromatic axis that aligns
+    # with the RGB achromatic line, so this would also project and clamp the achromatic
+    # value to the RGB achromatic line.
+    anchor = project_onto(anchor, bmax, bmin)
+
+    # Return white or black if the achromatic version is not within the RGB cube.
+    # HDR colors currently use the RGB maximum lightness. We do not currently
+    # clip HDR colors to SDR white, but that could be done if required.
+    if anchor == bmax:
+        color.update(rspace, bmax, mapcolor[-1])
+    elif anchor == bmin:
+        color.update(rspace, bmin, mapcolor[-1])
+    else:
+        # Ensure we are handling coordinates in the polar space to better retain hue
+        start = mapcoords[:]
+        end = achroma[:]
+
+        # Select an offset from the gamut surface according to unit type (64-bit for Python).
+        # 32-bit may require 1e-6
+        low = mn + alg.ATOL
+        high = mx + alg.ATOL
+
+        # Use an iterative process of casting rays to find the intersect with the RGB gamut
+        # and correcting the intersection onto the LCh chroma reduction path.
+        mapcoords[:] = from_oklch(mapcoords, m)
+        last = mapcoords[:]
+        if any(mn > x or x > mx for x in last):
+            for i in range(4):
+                if i:
+                    coords = to_oklch(mapcoords, mi)
+
+                    # Project the point onto the desired interpolation path in LCh if applying adaptive luminance
+                    if adaptive:
+                        coords = project_onto(coords, start, end)
+
+                    # For constant luminance, just correct lightness and hue in LCh
+                    else:
+                        coords[0] = start[0]
+                        coords[2] = start[2]
+                    mapcoords[:] = from_oklch(coords, m)
+
+                # Cast a ray and find the intersection with the gamut surface
+                coords = mapcoords[:]
+                intersection = raytrace_box(anchor, coords, bmin=bmin, bmax=bmax)
+
+                # If we cannot find an intersection, reset to last good color and quit
+                if not intersection:
+                    mapcoords[:] = last
+                    break
+
+                # Adjust anchor point closer to surface to improve results.
+                if i and all(low < x < high for x in coords):
+                    anchor = coords
+
+                # Update color with the intersection point on the RGB surface.
+                last = intersection
+                mapcoords[:] = last
+                continue
+
+        # Remove noise from floating point conversion.
+        color.update(rspace, [max(mn, min(mx, x)) for x in mapcoords], mapcolor[-1])
+
+
+def generic_path(
+    color: Color,
+    rspace: str,
+    cs: Space,
+    pspace: str,
+    adaptive: float,
+    mn: float,
+    mx: float,
+    coerced: bool,
+    **kwargs: Any
+) -> None:
+    """
+    Generic path for any perceptual space and coerced RGB handling that can be slower due to generalized logic.
+
+    Any perceptual space (Lab/LCh) can be used as the working space. In addition, RGB spaces do not have to be linear,
+    even though they are preferred. Lastly, cylindrical spaces with no associated RGB gamut can be coerced into a
+    geometric cube to allow for an increased chance of successful gamut mapping.
+    """
+
+    # Set the minimum bounds
+    bmax = [mx] * 3
+    bmin = [mn] * 3
+
+    # Ensure we are in the proper perceptual space or normalize values
+    orig = color.space()
+    mapcolor = color.convert(pspace, norm=False) if orig != pspace else color.clone().normalize(nans=False)
+
+    # Different perceptual spaces may have components in different orders so capture their indexes
+    # Calculate the achromatic version of the color
+    polar = mapcolor._space.is_polar()
+    achroma = mapcolor.clone()
+    if polar:
+        l, c, h = achroma._space.indexes()
+        achroma[c] = 0.0
+    else:
+        l, a, b = achroma._space.indexes()
+        achroma[a] = 0.0
+        achroma[b] = 0.0
+
+    # If value is provided for adaptive lightness, calculate a lightness
+    # anchor point relative to the hue independent mid point. Scale lightness and
+    # chroma by the max lightness to get lightness between 0 and 1.
+    if adaptive:
+        max_light = color.new('xyz-d65', WHITE).convert(pspace, in_place=True)[l]
+        achroma[l] = adaptive_hue_independent(
+            mapcolor[l] / max_light,
+            max(mapcolor[c] if polar else alg.rect_to_polar(mapcolor[a], mapcolor[b])[0], 0) / max_light,
+            adaptive
+        ) * max_light
+
+    # Calculate achromatic anchor.
+    anchor = cs.from_base(achroma.convert(rspace)[:-1]) if coerced else achroma.convert(rspace)[:-1]
+    # This allows us to find the maximum lightness for HDR RGB and SDR RGB.
+    # Some perceptual spaces do not have a traditional achromatic axis that aligns
+    # with the RGB achromatic line, so this would also project and clamp the achromatic
+    # value to the RGB achromatic line.
+    anchor = project_onto(anchor, bmax, bmin)
+
+    # Return white or black if the achromatic version is not within the RGB cube.
+    # HDR colors currently use the RGB maximum lightness. We do not currently
+    # clip HDR colors to SDR white, but that could be done if required.
+    if anchor == bmax:
+        color.update(rspace, cs.to_base(bmax) if coerced else bmax, mapcolor[-1])
+    elif anchor == bmin:
+        color.update(rspace, cs.to_base(bmin) if coerced else bmin, mapcolor[-1])
+    else:
+        # Ensure we are handling coordinates in the polar space to better retain hue
+        if polar:
+            start = mapcolor[:-1]
+            end = achroma[:-1]
+        else:
+            start = to_polar(mapcolor[:-1], a, b)
+            end = to_polar(achroma[:-1], a, b)
+            end[b] = start[b]
+
+        # Select an offset from the gamut surface according to unit type (64-bit for Python).
+        # 32-bit may require 1e-6
+        low = mn + alg.ATOL
+        high = mx + alg.ATOL
+
+        # Use an iterative process of casting rays to find the intersect with the RGB gamut
+        # and correcting the intersection onto the LCh chroma reduction path.
+        last = mapcolor.convert(rspace, in_place=True)[:-1]
+        if any(mn > x or x > mx for x in last):
+            for i in range(4):
+                if i:
+                    coords = mapcolor.convert(pspace, in_place=True, norm=False)[:-1]
+
+                    # Project the point onto the desired interpolation path in LCh if applying adaptive luminance
+                    if adaptive:
+                        if polar:
+                            mapcolor[:-1] = project_onto(coords, start, end)
+                        else:
+                            mapcolor[:-1] = to_rect(project_onto(to_polar(coords, a, b), start, end), a, b)
+
+                    # For constant luminance, just correct lightness and hue in LCh
+                    else:
+                        coords[l] = start[l]
+                        if polar:
+                            coords[h] = start[h]
+                        else:
+                            to_polar(coords, a, b)
+                            coords[b] = start[b]
+                            to_rect(coords, a, b)
+                        mapcolor[:-1] = coords
+
+                    mapcolor.convert(rspace, in_place=True)
+
+                # Cast a ray and find the intersection with the gamut surface
+                coords = cs.from_base(mapcolor[:-1]) if coerced else mapcolor[:-1]
+                intersection = raytrace_box(anchor, coords, bmin=bmin, bmax=bmax)
+
+                # If we cannot find an intersection, reset to last good color and quit
+                if not intersection:
+                    mapcolor[:-1] = last
+                    break
+
+                # Adjust anchor point closer to surface to improve results.
+                if i and all(low < x < high for x in coords):
+                    anchor = coords
+
+                # Update color with the intersection point on the RGB surface.
+                last = cs.to_base(intersection) if coerced else intersection
+                mapcolor[:-1] = last
+                continue
+
+        # Remove noise from floating point conversion.
+        if coerced:
+            mapcolor[:-1] = cs.to_base([max(mn, min(mx, x)) for x in cs.from_base(mapcolor[:-1])])
+        else:
+            mapcolor[:-1] = [max(mn, min(mx, x)) for x in mapcolor[:-1]]
+        color.update(mapcolor)
+
+
 class RayTrace(Fit):
     """Gamut mapping by using ray tracing."""
 
@@ -138,7 +434,7 @@ class RayTrace(Fit):
         adaptive: float = 0.0,
         **kwargs: Any
     ) -> None:
-        """Scale the color within its gamut but preserve L and h as much as possible."""
+        """Use ray tracing with a linear RGB space for a geometric approach to reducing chroma."""
 
         if pspace is None:
             pspace = self.PSPACE
@@ -166,113 +462,13 @@ class RayTrace(Fit):
                 mx = color.new(space, [mx] * 3).convert(linear, in_place=True)[0]
             space = linear
 
-        # Get the minimum bounds
-        bmax = [mx] * 3
+        # Get minimum
         mn = cs.CHANNELS[0].low
-        bmin = [mn] * 3
 
-        orig = color.space()
-        mapcolor = color.convert(pspace, norm=False) if orig != pspace else color.clone().normalize(nans=False)
-        polar = mapcolor._space.is_polar()
-        achroma = mapcolor.clone()
-
-        # Different perceptual spaces may have components in different orders so capture their indexes
-        if polar:
-            l, c, h = achroma._space.indexes()
-            achroma[c] = 0.0
+        # If we are gamut mapping using Oklab/OkLCh, per the CSS spec, and we are
+        # gamut mapping within an linear RGB gamut, use the CSS fast path that
+        # reduces overhead and is optimized for OkLCh and linear RGB.
+        if pspace in CSS_FAST_PATH and not coerced and hasattr(cs, TO_RGB):
+            css_fast_path(color, cs, pspace, adaptive, mn, mx)
         else:
-            l, a, b = achroma._space.indexes()
-            achroma[a] = 0.0
-            achroma[b] = 0.0
-
-        # If an alpha value is provided for adaptive lightness, calculate a lightness
-        # anchor point relative to the hue independent mid point. Scale lightness and
-        # chroma by the max lightness to get lightness between 0 and 1.
-        if adaptive:
-            max_light = color.new('xyz-d65', WHITE).convert(pspace, in_place=True)[l]
-            achroma[l] = adaptive_hue_independent(
-                mapcolor[l] / max_light,
-                max(mapcolor[c] if polar else alg.rect_to_polar(mapcolor[a], mapcolor[b])[0], 0) / max_light,
-                adaptive
-            ) * max_light
-
-        # Some perceptual spaces, such as CAM16 or HCT, may compensate for adapting
-        # luminance which may give an achromatic that is not quite achromatic.
-        # Project the lightness point back onto to the gamut's achromatic line.
-        anchor = cs.from_base(achroma.convert(space)[:-1]) if coerced else achroma.convert(space)[:-1]
-        anchor = project_onto(anchor, bmax, bmin)
-
-        # Return white or black if the achromatic version is not within the RGB cube.
-        # HDR colors currently use the RGB maximum lightness. We do not currently
-        # clip HDR colors to SDR white, but that could be done if required.
-        if anchor == bmax:
-            color.update(space, cs.to_base(bmax) if coerced else bmax, mapcolor[-1])
-        elif anchor == bmin:
-            color.update(space, cs.to_base(bmin) if coerced else bmin, mapcolor[-1])
-        else:
-            # Ensure we are handling coordinates in the polar space to better retain hue
-            if polar:
-                start = mapcolor[:-1]
-                end = achroma[:-1]
-            else:
-                start = to_polar(mapcolor[:-1], a, b)
-                end = to_polar(achroma[:-1], a, b)
-                end[b] = start[b]
-
-            # Offset is required for some perceptual spaces that are sensitive
-            # to anchors that get too close to the surface.
-            low = mn + 1e-12
-            high = mx + 1e-12
-
-            # Use an iterative process of casting rays to find the intersect with the RGB gamut
-            # and correcting the intersection onto the LCh chroma reduction path.
-            last = mapcolor.convert(space, in_place=True)[:-1]
-            if any(mn > x or x > mx for x in last):
-                for i in range(4):
-                    if i:
-                        coords = mapcolor.convert(pspace, in_place=True, norm=False)[:-1]
-
-                        # Project the point onto the desired interpolation path in LCh if applying adaptive luminance
-                        if adaptive:
-                            if polar:
-                                mapcolor[:-1] = project_onto(coords, start, end)
-                            else:
-                                mapcolor[:-1] = to_rect(project_onto(to_polar(coords, a, b), start, end), a, b)
-
-                        # For constant luminance, just correct lightness and hue in LCh
-                        else:
-                            coords[l] = start[l]
-                            if polar:
-                                coords[h] = start[h]
-                            else:
-                                to_polar(coords, a, b)
-                                coords[b] = start[b]
-                                to_rect(coords, a, b)
-                            mapcolor[:-1] = coords
-
-                        mapcolor.convert(space, in_place=True)
-
-                    # Cast a ray and find the intersection with the gamut surface
-                    coords = cs.from_base(mapcolor[:-1]) if coerced else mapcolor[:-1]
-                    intersection = raytrace_box(anchor, coords, bmin=bmin, bmax=bmax)
-
-                    # If we cannot find an intersection, reset to last good color and quit
-                    if not intersection:
-                        mapcolor[:-1] = last
-                        break
-
-                    # Adjust anchor point closer to surface to improve results.
-                    if i and all(low < x < high for x in coords):
-                        anchor = coords
-
-                    # Update color with the intersection point on the RGB surface.
-                    last = cs.to_base(intersection) if coerced else intersection
-                    mapcolor[:-1] = last
-                    continue
-
-            # Remove noise from floating point conversion.
-            if coerced:
-                mapcolor[:-1] = cs.to_base([max(mn, min(mx, x)) for x in cs.from_base(mapcolor[:-1])])
-            else:
-                mapcolor[:-1] = [max(mn, min(mx, x)) for x in mapcolor[:-1]]
-            color.update(mapcolor)
+            generic_path(color, space, cs, pspace, adaptive, mn, mx, coerced)

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,6 +3,11 @@ icon: lucide/scroll-text
 ---
 # Changelog
 
+## 8.10
+
+-   **NEW** Provide an more optimized path for the default Ray Trace when using OkLCh as the perceptual space and gamut
+    mapping linear RGB gamuts.
+
 ## 8.9
 
 -   **NEW**: Add support for CSS analogous component sets in interpolation and mixing.

--- a/tests/test_gamut.py
+++ b/tests/test_gamut.py
@@ -344,6 +344,40 @@ class TestRayTrace(util.ColorAsserts, unittest.TestCase):
             Color('color(display-p3 0.89593 0.90035 0.29412)')
         )
 
+    def test_raytrace_adaptive_lightness_generic_lab(self):
+        """Test ray trace adaptive lightness in ray trace using generic path."""
+
+        options = {"method": 'raytrace', "pspace": 'lab-d65', "adaptive": 0.05}
+
+        self.assertColorEqual(
+            Color('display-p3', [1, 1, 0]).fit('srgb', **options),
+            Color('color(display-p3 0.97355 0.94922 0.31413)')
+        )
+
+        options['adaptive'] = 5
+
+        self.assertColorEqual(
+            Color('display-p3', [1, 1, 0]).fit('srgb', **options),
+            Color('color(display-p3 0.83876 0.81766 0.26577)')
+        )
+
+    def test_raytrace_adaptive_lightness_generic_lch(self):
+        """Test ray trace adaptive lightness in ray trace using generic path."""
+
+        options = {"method": 'raytrace', "pspace": 'lch-d65', "adaptive": 0.05}
+
+        self.assertColorEqual(
+            Color('display-p3', [1, 1, 0]).fit('srgb', **options),
+            Color('color(display-p3 0.97355 0.94922 0.31413)')
+        )
+
+        options['adaptive'] = 5
+
+        self.assertColorEqual(
+            Color('display-p3', [1, 1, 0]).fit('srgb', **options),
+            Color('color(display-p3 0.83876 0.81766 0.26577)')
+        )
+
     def test_edge_case_raytrace_adaptive_lightness_lch(self):
         """Test edge case ray trace adaptive lightness."""
 

--- a/tools/gamutcheck.py
+++ b/tools/gamutcheck.py
@@ -65,6 +65,7 @@ def run(gamut, space, gmap, max_chroma, calc_near):
                 coords = to_rect(coords, a, b)
             c1 = Color(space, coords)
             c2 = c1.clone().fit(gamut, **gmap)
+            assert c2.in_gamut(gamut), c2.convert(gamut).serialize()
             de = c1.delta_e(c2, method='2000')
             dl = (c1[l] - c2[l])
             if abs(dl) > abs(max_delta_l):
@@ -120,9 +121,11 @@ def run(gamut, space, gmap, max_chroma, calc_near):
             start = end + 1
 
     if calc_near:
-        for r, g, b in it.product(range(101), range(101), range(101)):
-            c1 = Color('display-p3', [r / 100, g / 100, b / 100]).convert(space)
-            c2 = c1.clone().fit('srgb', **gmap)
+        gamut = 'srgb'
+        for r, g, b in it.product(range(steps + 1), range(steps + 1), range(steps + 1)):
+            c1 = Color('display-p3', [r / steps, g / steps, b / steps]).convert(space)
+            c2 = c1.clone().fit(gamut, **gmap)
+            assert c2.in_gamut(gamut), c2.convert(gamut).serialize()
             dl = (c1[l] - c2[l])
             if abs(dl) > abs(max_delta_l):
                 max_delta_l = dl


### PR DESCRIPTION
We can't make global optimizations for every combination of perceptual
space and gamut when doing ray trace, but we can provide an optimized
path for the default (OkLCh perceptual space) and linear RGB spaces.
This is the path that CSS would take, and what we originally wrote the
approach for. While even faster approaches may end up making it into
CSS, Ray Trace is more flexible as a default here that handles gamut
mapping with various perceptual spaces, optimizing the default case
can improve general performance.

Resolves #520